### PR TITLE
docs: add table of contents to benchmarking.md

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -3,6 +3,26 @@
 How to measure how the server behaves under concurrent load — the "tokens/sec vs
 concurrent users" curve popularised by Alex Ziskind's local-LLM videos.
 
+## Contents
+
+- [Tooling](#tooling)
+- [Quick start — Ziskind's harness against LiteLLM](#quick-start--ziskinds-harness-against-litellm)
+- [The critical caveat: `--parallel N` caps concurrency](#the-critical-caveat---parallel-n-caps-concurrency)
+- [Baseline results (2026-07-21)](#baseline-results-2026-07-21)
+- [`--parallel` throughput sweep (2026-07-21)](#--parallel-throughput-sweep-2026-07-21)
+  - [The catch: `--parallel N` divides per-request context](#the-catch---parallel-n-divides-per-request-context)
+- [MoE on the P100 (16 GB) — Gemma-4-26B-A4B (2026-07-22)](#moe-on-the-p100-16-gb--gemma-4-26b-a4b-2026-07-22)
+  - [Context ceiling + parallel scaling at large context (2026-07-22)](#context-ceiling--parallel-scaling-at-large-context-2026-07-22)
+- [ComfyUI image generation — P100 vs V100 (txt2img, 2026-07-22)](#comfyui-image-generation--p100-vs-v100-txt2img-2026-07-22)
+- [Single-stream engine benchmarks (`llama-bench`, 2026-07-01/02)](#single-stream-engine-benchmarks-llama-bench-2026-07-0102)
+  - [Coding-model benchmark — Qwen3.6-27B on the V100s (2026-07-01)](#coding-model-benchmark--qwen36-27b-on-the-v100s-2026-07-01)
+  - [MoE benchmark — Qwen3.6-35B-A3B on the V100s (2026-07-01)](#moe-benchmark--qwen36-35b-a3b-on-the-v100s-2026-07-01)
+  - [Uncensored fine-tune smoke test — Qwen3.6-35B-A3B-Uncensored (HauhauCS-Aggressive, 2026-07-01)](#uncensored-fine-tune-smoke-test--qwen36-35b-a3b-uncensored-hauhaucs-aggressive-2026-07-01)
+  - [Tensor-parallel / multi-GPU reality (measured 2026-07-01)](#tensor-parallel--multi-gpu-reality-measured-2026-07-01)
+  - [coding context-window sweep (2026-07-02)](#coding-context-window-sweep-2026-07-02)
+  - [Prompt-processing (prefill) tuning — `--ubatch-size` (2026-07-02)](#prompt-processing-prefill-tuning----ubatch-size-2026-07-02)
+  - [Gemma-4 benchmarks + context/ubatch tuning (2026-07-02)](#gemma-4-benchmarks--contextubatch-tuning-2026-07-02)
+
 ## Tooling
 
 | Tool | Layer | What it measures | Use it for |


### PR DESCRIPTION
Adds a **Contents** section to `docs/benchmarking.md` linking every `##`/`###` section (GitHub-style anchors), for easier navigation of the growing benchmark log.

Docs-only; no code or behavior changes.