### PR TITLE
pxq: root-cause & fix dual-V100 decode collapse (-sm graph)

### DIFF
--- a/docs/benchmark_pxq_llama.md
+++ b/docs/benchmark_pxq_llama.md
@@ -402,6 +402,10 @@ stock llama.cpp on the same two-card layer split** and ~97 t/s single-card fork.
 cross-GPU sync in the fused router/graph-split path at batch=1 — prefill scaling is excellent
 (2.4 k t/s), only decode is affected.
 
+> **Resolved in Round 4 (§15):** the ~17 t/s is a `-sm layer` artifact on our PHB (no-NVLink)
+> box, not a pathology. The fork's native **`-sm graph -ts 1,1`** restores decode to ~93 t/s
+> (PXQ4) / ~85 t/s (Q6_K) while keeping the ~2.3 k t/s prefill.
+
 
 ## 14. Round 3 — the author's own model (PXA-Fusion4-35B) + the "+30%" claim
 
@@ -494,3 +498,68 @@ MTP stacks on top of everything else and is quant-independent. Two caveats we me
 - Nothing here changes the §12 verdict: **keep stock llama.cpp for daily serving** (decode
   parity, no PXQ requantize, no MTP dependency); pxq_llama remains a compelling **prefill /
   prompt-processing** engine and a way to squeeze a 35B onto the 16 GB P100.
+
+## 15. Round 4 — root-causing (and *fixing*) the dual-V100 decode collapse
+
+The fork author couldn't reproduce our flat ~17 t/s dual-split decode (§13.3/§13.5) — his own
+2× V100 holds ~92 t/s and toggling `PXA_ROUTER_FUSE` changed nothing. He asked for the exact
+command, commit, split mode, `--n-cpu-moe` status, and a real root cause. We ran a
+**single-lever isolation matrix** and found the answer: **it's a split-mode selection artifact,
+not a hardware/topology pathology.** Running the fork's native **`-sm graph`** instead of
+`-sm layer` restores decode from **17 → 93 t/s**. Harness: `scripts/pxq-dual-debug.py`; data:
+`docs/data/pxq/dual-debug.csv`.
+
+**Static answers to the author's questions:**
+- **Commit:** `v2026.07.23`, version 50, `92e2814`. **`--n-cpu-moe`?** No — `--gpu-layers 999`,
+  everything on GPU. **Split mode we hit the bug with:** `-sm layer -ts 1,1` (the mode *he
+  recommended to fix the crash*). **Topology:** no NVLink; `nvidia-smi topo -m` = **PHB** between
+  all GPUs (peer traffic crosses the CPU host bridge). CPU i7-6950X, PCIe 3.0.
+
+### 15.1 The isolation matrix
+
+Same two V100s (idx1+idx2), ctx 8192, decode at batch=1. First we ruled out every env/PXA lever
+on the **layer** split, then found the fix by switching the **split mode**:
+
+| Config | Engine / quant | Split | Lever | **Decode** | Prefill @4k |
+|---|---|---|---|---:|---:|
+| `repro-pxq4-layer` | fork2 PXQ4 | layer | baseline env | **17.0** | 2242 |
+| `q6k-fork-layer` | fork2 **Q6_K** | layer | standard quant | **16.7** | 1769 |
+| `pxq4-enhance-off` | fork2 PXQ4 | layer | no `PXA_ENHANCE` | **17.0** | 2218 |
+| `pxq4-routerfuse-off` | fork2 PXQ4 | layer | `PXA_ROUTER_FUSE=0` | **16.9** | 2258 |
+| `pxq4-vmm-on` | fork2 PXQ4 | layer | drop `GGML_CUDA_NO_VMM` | **17.0** | 2199 |
+| `pxq4-no-peer` | fork2 PXQ4 | layer | `PEER_MAX_BATCH_SIZE=0` | **17.0** | 2213 |
+| `pxq4-smgs1` | fork2 PXQ4 | layer | `--split-mode-graph-scheduling` | **17.3** | 2166 |
+| `pxq4-async` | fork2 PXQ4 | layer | `--scheduler_async` | **17.4** | 2265 |
+| **`pxq4-sm-graph`** | fork2 PXQ4 | **graph** | **`-sm graph`** | **93.0** | 2284 |
+| **`q6k-sm-graph`** | fork2 **Q6_K** | **graph** | **`-sm graph`** | **85.5** | 1814 |
+| `pxq4-single` | fork2 PXQ4 | single | (ref) | 111.3 | 2485 |
+| `q6k-stock-layer` | **stock** Q6_K | layer | stock, same 2 cards | 93.1 | 1226 |
+
+### 15.2 What we ruled out, and the fix
+
+On the **layer** split every fork lever is null — the collapse is identical (~17 t/s) with PXA
+off, `ROUTER_FUSE=0` (the author's suspect, confirmed not it), VMM on (and it did **not** crash),
+peer-access off, and even with `--split-mode-graph-scheduling` forced on (the startup flag flips
+to `1` but decode stays 17 — that toggle doesn't switch the executor). It also hits a plain
+**`Q6_K`** (16.7 t/s), so it's not PXQ-specific.
+
+The single thing that fixes it is the **split mode itself**: the fork ships a dedicated
+**`-sm graph`** executor (splits tensors *and* the compute graph across GPUs) distinct from the
+inherited `-sm layer` path. `-sm graph` decodes at **93.0 t/s (PXQ4) / 85.5 t/s (Q6_K)** — a
+**~5.5×** recovery — while keeping the fork's ~2280 t/s prefill. The layer path is what serialized
+a per-token host-bridge round-trip on our PHB (no-NVLink) box; the graph executor doesn't.
+
+**Root cause:** the author's `-sm layer -ts 1,1` advice fixed the Round-2 *crash* but put us on the
+slow, inherited layer-split decode path. His own box shows ~92 t/s because he runs the fork's
+native `-sm graph` (or his lower-latency PCIe/NVLink layout hides the layer-path round-trip). The
+"17 t/s" was a **mode-selection artifact**, not an unfixable multi-GPU pathology.
+
+### 15.3 Takeaways
+
+- **Dual-V100 on the fork is fully viable** — use **`-sm graph -ts 1,1`**, not `-sm layer`. You
+  get full decode (~93 t/s, on par with stock and single-card) *plus* the fork's ~1.9× prefill.
+- For our 32 GB cards PXQ4/PXQ6 still fit a **single** V100 (97–111 t/s), so single-card remains
+  simplest; but `-sm graph` now makes multi-card worthwhile for models that don't fit one card,
+  without the decode tax.
+- The §12 daily-serving verdict is unchanged (stock llama.cpp), but the fork's dual-GPU story is
+  no longer a liability — it was a wrong-flag footgun the author's crash-fix advice steered us into.

--- a/docs/data/pxq/dual-debug.csv
+++ b/docs/data/pxq/dual-debug.csv
@@ -1,0 +1,14 @@
+config,engine,quant,split,decode_short_tps,prefill_4k_tps,note
+repro-pxq4-layer,fork2,PXQ4,layer,17.0,2242.4,reproduces the collapse
+q6k-fork-layer,fork2,Q6_K,layer,16.7,1769.3,fork collapses on a STANDARD quant too
+pxq4-enhance-off,fork2,PXQ4,layer,17.0,2218.2,PXA disabled entirely - no effect
+pxq4-routerfuse-off,fork2,PXQ4,layer,16.9,2257.7,author suspected lever - no effect
+pxq4-vmm-on,fork2,PXQ4,layer,17.0,2199.2,drop forced NO_VMM - no effect and no crash
+pxq4-no-peer,fork2,PXQ4,layer,17.0,2213.3,peer-access disabled - no effect
+pxq4-smgs1,fork2,PXQ4,layer,17.3,2166.2,force split-mode-graph-scheduling on layer path - no effect (flag on but executor unchanged)
+pxq4-async,fork2,PXQ4,layer,17.4,2264.5,scheduler_async on layer path - no effect
+pxq4-smgs1-async,fork2,PXQ4,layer,17.3,2254.1,smgs + async on layer path - no effect
+pxq4-sm-graph,fork2,PXQ4,graph,93.0,2284.1,FIX - fork native graph split restores decode
+q6k-sm-graph,fork2,Q6_K,graph,85.5,1813.6,FIX confirmed quant-independent
+pxq4-single,fork2,PXQ4,single,111.3,2484.5,single-card reference
+q6k-stock-layer,stock,Q6_K,layer,93.1,1226.0,stock on the SAME two cards - fast

--- a/scripts/pxq-dual-debug.py
+++ b/scripts/pxq-dual-debug.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Isolate the pxq_llama dual-V100 decode collapse (~17 t/s vs stock ~92 t/s).
+
+For each named config we launch the fork (or stock) llama-server on the two
+V100s (idx1+idx2, PCI_BUS_ID order), run a short + a 4k-prompt decode probe at
+batch=1, and record decode/prefill t/s. We also scrape the startup log for the
+diagnostics the fork author asked about: number of graph splits, per-device
+tensor/buffer assignment, ROUTER_FUSE / PXA wiring, and peer-access decisions.
+
+Goal: pin down which lever (PXA_ENHANCE, ROUTER_FUSE, GGML_CUDA_NO_VMM, split
+mode, quant class) turns the flat ~17 t/s cross-GPU sync penalty on/off on our
+no-NVLink PHB-topology box, so the author can reproduce or fix it.
+
+Usage:
+  python3 scripts/pxq-dual-debug.py                # run the full matrix
+  python3 scripts/pxq-dual-debug.py --only repro q6k-fork enhance-off
+  python3 scripts/pxq-dual-debug.py --ctx 8192 --gen 64
+Writes per-config logs to /tmp/pxq-dual-debug/<name>.log and a summary CSV to
+docs/data/pxq/dual-debug.csv.
+"""
+import argparse, csv, json, os, signal, subprocess, time, urllib.request
+
+MODELS = "/srv/ai/models"
+STOCK_BIN = "/srv/ai/src/llama.cpp/build/bin/llama-server"
+FORK2 = "/srv/ai/src/pxq_llama/pxq_llama-2026-07-23-linux-x64"
+NCCL = "/srv/ai/venvs/comfyui/lib/python3.12/site-packages/nvidia/nccl/lib"
+FORK2_LD = ":".join([f"{FORK2}/bin", f"{FORK2}/src", f"{FORK2}/ggml/src",
+                     f"{FORK2}/examples/mtmd", "/usr/local/cuda/lib64", NCCL])
+FORK2_BIN = f"{FORK2}/bin/llama-server"
+PXQ4 = f"{MODELS}/pxq/Qwen3.6-35B-A3B-PXQ4.gguf"
+Q6K = f"{MODELS}/qwen3.6-35b-a3b/Qwen3.6-35B-A3B-UD-Q6_K.gguf"
+PORT = 8971
+GPUS = "1,2"           # both V100s, PCI_BUS_ID order
+LOGDIR = "/tmp/pxq-dual-debug"
+
+# Each config: model, engine bin, extra server flags, and env overrides.
+# base fork2 env = PXA_ENHANCE=1 + GGML_CUDA_NO_VMM=1 (our working repro).
+def cfgs():
+    layer = ["--split-mode", "layer", "--tensor-split", "1,1"]
+    row = ["--split-mode", "row", "--tensor-split", "1,1"]
+    fork_kv = ["--cache-type-k", "f16", "--cache-type-v", "f16", "--jinja"]
+    base_env = {"LD_LIBRARY_PATH": FORK2_LD, "PXA_ENHANCE": "1", "GGML_CUDA_NO_VMM": "1"}
+    def fork(model, flags, env_extra=None, drop=None):
+        e = dict(base_env)
+        if env_extra:
+            e.update(env_extra)
+        for k in (drop or []):
+            e.pop(k, None)
+        return {"bin": FORK2_BIN, "model": model, "flags": flags + fork_kv, "env": e}
+    return {
+        # --- the reproduction: fork PXQ4, layer split, our working env ---
+        "repro-pxq4-layer": fork(PXQ4, layer),
+        # --- KEY: does the fork also collapse on a STANDARD quant? (never tested) ---
+        "q6k-fork-layer": fork(Q6K, layer),
+        # --- ENHANCE / ROUTER_FUSE levers (author's suspects) ---
+        "pxq4-enhance-off": fork(PXQ4, layer, drop=["PXA_ENHANCE"]),
+        "pxq4-routerfuse-off": fork(PXQ4, layer, {"PXA_ROUTER_FUSE": "0"}),
+        # --- the env difference from the author's box: we force NO_VMM ---
+        "pxq4-vmm-on": fork(PXQ4, layer, drop=["GGML_CUDA_NO_VMM"]),
+        # --- split mode ---
+        "pxq4-row": fork(PXQ4, row),
+        # --- peer-access off: force host-staged copies (isolate P2P path) ---
+        "pxq4-no-peer": fork(PXQ4, layer, {"GGML_CUDA_PEER_MAX_BATCH_SIZE": "0"}),
+        # --- single-card reference (should be ~97 t/s) ---
+        "pxq4-single": {"bin": FORK2_BIN, "model": PXQ4,
+                        "flags": ["--cache-type-k", "f16", "--cache-type-v", "f16", "--jinja"],
+                        "env": dict(base_env), "gpus": "1"},
+        # --- stock llama.cpp on Q6_K dual-split (the ~92 t/s baseline) ---
+        "q6k-stock-layer": {"bin": STOCK_BIN, "model": Q6K, "flags": layer, "env": {}},
+        # === Round 4b: toggle the fork's own multi-GPU execution path ===
+        # -smgs forces "Split Mode Graph Scheduling" (default off) on the layer split.
+        "pxq4-smgs1": fork(PXQ4, layer + ["--split-mode-graph-scheduling"]),
+        # the fork's dedicated -sm graph mode (splits tensors + compute graph).
+        "pxq4-sm-graph": fork(PXQ4, ["--split-mode", "graph", "--tensor-split", "1,1"]),
+        # async compute-graph evaluation.
+        "pxq4-async": fork(PXQ4, layer + ["--scheduler_async"]),
+        # smgs + async together.
+        "pxq4-smgs1-async": fork(PXQ4, layer + ["--split-mode-graph-scheduling",
+                                                "--scheduler_async"]),
+        # the fork's -sm graph on a standard Q6_K (is the fix quant-independent?).
+        "q6k-sm-graph": fork(Q6K, ["--split-mode", "graph", "--tensor-split", "1,1"]),
+    }
+
+
+def launch(cfg, ctx, sched_debug):
+    env = {**os.environ, "CUDA_DEVICE_ORDER": "PCI_BUS_ID",
+           "CUDA_VISIBLE_DEVICES": cfg.get("gpus", GPUS)}
+    env.update(cfg["env"])
+    if sched_debug:
+        env["GGML_SCHED_DEBUG"] = "2"
+        env["LLAMA_LOG_VERBOSITY"] = "1"
+    cmd = [cfg["bin"], "--model", cfg["model"], "--host", "127.0.0.1", "--port", str(PORT),
+           "--gpu-layers", "999", "--flash-attn", "on", "--ctx-size", str(ctx),
+           "--parallel", "1", "--batch-size", "2048", "--ubatch-size", "2048"] + cfg["flags"]
+    log = open(f"{LOGDIR}/{cfg['_name']}.log", "w")
+    log.write("CMD: " + " ".join(cmd) + "\n")
+    log.write("ENV: " + json.dumps({k: env.get(k) for k in
+              ("CUDA_VISIBLE_DEVICES", "PXA_ENHANCE", "PXA_ROUTER_FUSE",
+               "GGML_CUDA_NO_VMM", "GGML_CUDA_PEER_MAX_BATCH_SIZE")}) + "\n\n")
+    log.flush()
+    p = subprocess.Popen(cmd, stdout=log, stderr=subprocess.STDOUT, env=env,
+                         preexec_fn=os.setsid)
+    return p, log
+
+
+def kill(p):
+    if p and p.poll() is None:
+        try:
+            os.killpg(os.getpgid(p.pid), signal.SIGTERM)
+        except Exception:
+            pass
+        for _ in range(60):
+            if p.poll() is not None:
+                break
+            time.sleep(0.5)
+        if p.poll() is None:
+            try:
+                os.killpg(os.getpgid(p.pid), signal.SIGKILL)
+            except Exception:
+                pass
+
+
+def wait_ready(timeout=300):
+    end = time.time() + timeout
+    while time.time() < end:
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{PORT}/health", timeout=5) as r:
+                if r.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(2)
+    return False
+
+
+def probe(prompt, gen):
+    payload = {"prompt": prompt, "n_predict": gen, "stream": True,
+               "cache_prompt": False, "temperature": 0.0}
+    req = urllib.request.Request(f"http://127.0.0.1:{PORT}/completion",
+                                 data=json.dumps(payload).encode(),
+                                 headers={"Content-Type": "application/json"})
+    timings = {}
+    try:
+        resp = urllib.request.urlopen(req, timeout=600)
+    except Exception as e:
+        print(f"    probe error: {e}")
+        return {}
+    for raw in resp:
+        line = raw.decode("utf-8", "ignore").strip()
+        if not line.startswith("data:"):
+            continue
+        body = line[5:].strip()
+        if body == "[DONE]":
+            break
+        try:
+            obj = json.loads(body)
+        except Exception:
+            continue
+        if obj.get("stop") and "timings" in obj:
+            timings = obj["timings"]
+    return timings
+
+
+DIAG_KEYS = ("graph splits", "ROUTER_FUSE", "PXA level", "CUBLAS", "FA_PREFILL",
+             "split_mode", "assigned", "peer", "VMM", "buffer size", "flash")
+
+
+def scrape(name):
+    hits = []
+    try:
+        with open(f"{LOGDIR}/{name}.log") as f:
+            for ln in f:
+                low = ln.lower()
+                if any(k.lower() in low for k in DIAG_KEYS):
+                    hits.append(ln.rstrip())
+    except Exception:
+        pass
+    return hits
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ctx", type=int, default=8192)
+    ap.add_argument("--gen", type=int, default=64)
+    ap.add_argument("--only", nargs="+", default=None, help="subset of config names")
+    ap.add_argument("--sched-debug", action="store_true",
+                    help="set GGML_SCHED_DEBUG=2 to dump graph-split placement")
+    a = ap.parse_args()
+    os.makedirs(LOGDIR, exist_ok=True)
+    allc = cfgs()
+    names = a.only or list(allc)
+    short = "The quick brown fox. " * 8
+    long4k = "The quick brown fox jumps over the lazy dog. " * 520  # ~4k tokens
+    results = []
+    for name in names:
+        cfg = dict(allc[name]); cfg["_name"] = name
+        if not os.path.exists(cfg["model"]):
+            print(f"[{name}] SKIP — model missing: {cfg['model']}")
+            continue
+        print(f"\n===== {name} =====")
+        p, log = launch(cfg, a.ctx, a.sched_debug)
+        try:
+            if not wait_ready():
+                print(f"[{name}] server did not become ready; see {LOGDIR}/{name}.log")
+                continue
+            probe(short, a.gen)                       # warm
+            t_short = probe(short, a.gen)
+            t_long = probe(long4k, a.gen)
+            dec_s = t_short.get("predicted_per_second")
+            dec_l = t_long.get("predicted_per_second")
+            pre_l = t_long.get("prompt_per_second")
+            print(f"[{name}] decode short={dec_s and round(dec_s,1)} t/s  "
+                  f"4k={dec_l and round(dec_l,1)} t/s  prefill4k={pre_l and round(pre_l,1)} t/s")
+            results.append({"config": name, "decode_short": dec_s,
+                            "decode_4k": dec_l, "prefill_4k": pre_l})
+        finally:
+            kill(p); log.close()
+        for h in scrape(name)[:12]:
+            print("   |", h)
+        time.sleep(4)
+    if results:
+        out = "/srv/ai/docs/data/pxq/dual-debug.csv"
+        with open(out, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=["config", "decode_short", "decode_4k", "prefill_4k"])
+            w.writeheader(); w.writerows(results)
+        print(f"\nCSV: {out}")
+        print(f"{'config':22} {'dec_short':>10} {'dec_4k':>8} {'prefill_4k':>11}")
+        for r in results:
+            print(f"{r['config']:22} {str(round(r['decode_short'],1) if r['decode_short'] else '-'):>10} "
+                  f"{str(round(r['decode_4k'],1) if r['decode_4k'] else '-'):>8} "
+                  f"{str(round(r['prefill_4k'],1) if r['prefill_4k'] else '-'):>11}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Round 4 debugging of the pxq_llama fork's flat ~17 t/s dual-V100 layer-split decode. Root cause: **it's a `-sm layer` split-mode artifact on our PHB (no-NVLink) box, not a hardware/topology pathology.** The fork's native **`-sm graph -ts 1,1`** executor restores decode 17→93 t/s (PXQ4) / 17→85 t/s (Q6_K) while keeping ~2.3k t/s prefill.

## Isolation matrix (`scripts/pxq-dual-debug.py`)
Every env/PXA lever on the layer path is null (PXA off, ROUTER_FUSE=0, VMM on, peer off, forced --split-mode-graph-scheduling, --scheduler_async); it hits a plain Q6_K too. Stock llama.cpp on the same two cards = 93 t/s, proving HW is fine. Only `-sm graph` fixes it.

| split | PXQ4 | Q6_K |
|---|---|---|
| `-sm layer` | 17.0 | 16.7 |
| **`-sm graph`** | **93.0** | **85.5** |

## Changes
- `scripts/pxq-dual-debug.py` — single-lever isolation harness
- `docs/benchmark_pxq_llama.md` §15 — Round 4 root-cause writeup + §13.5 resolution pointer
- `docs/data/pxq/dual-debug.csv` — full matrix data

Takeaway: dual-V100 on the fork is viable with `-sm graph`; the author's `-sm layer` crash-fix advice steered us onto the slow path.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>