### PR TITLE
bench(mtp): ngram-mod + draft-mtp hybrid on coding slot

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -17,6 +17,7 @@ concurrent users" curve popularised by Alex Ziskind's local-LLM videos.
 - [P100 `fast` slot: 12B dense vs 26B-A4B MoE — TTFT & prefill (2026-07-22)](#p100-fast-slot-12b-dense-vs-26b-a4b-moe--ttft--prefill-2026-07-22)
 - [MTP speculative decode on our `chat` model — Qwen3.6-35B-A3B (2026-07-23)](#mtp-speculative-decode-on-our-chat-model--qwen36-35b-a3b-2026-07-23)
   - [MTP on the `coding` model — Qwen3.6-27B Q6_K (2026-07-23)](#mtp-on-the-coding-model--qwen36-27b-q6_k-2026-07-23)
+  - [Chaining `ngram-mod` before `draft-mtp` on the `coding` slot (2026-07-25)](#chaining-ngram-mod-before-draft-mtp-on-the-coding-slot-2026-07-25)
   - [MTP on the uncensored `chat-uncensored-q6` model — Qwen3.6-35B-A3B heretic (2026-07-23)](#mtp-on-the-uncensored-chat-uncensored-q6-model--qwen36-35b-a3b-heretic-2026-07-23)
   - [MTP on the `gemma-31b` model — Gemma-4-31B dense, separate draft head (2026-07-23)](#mtp-on-the-gemma-31b-model--gemma-4-31b-dense-separate-draft-head-2026-07-23)
   - [MTP benefit by prompt type & temperature — is "MTP hurts creative writing" a Metal artefact? (2026-07-24)](#mtp-benefit-by-prompt-type--temperature--is-mtp-hurts-creative-writing-a-metal-artefact-2026-07-24)
@@ -622,6 +623,66 @@ llama-server \
 > MTP is a **single-stream latency** win, so the `agentic` mode (which runs `coding` as a P=2
 > throughput pool) overrides back to the non-MTP Q6_K file at 200k with spec off; `heavy-coding`
 > keeps MTP on the single-slot interactive `coding` primary.
+
+### Chaining `ngram-mod` before `draft-mtp` on the `coding` slot (2026-07-25)
+
+A reader of the MTP benchmarks suggested chaining a **model-free n-gram drafter ahead of MTP**
+on a coding slot:
+
+```bash
+--spec-type draft-mtp,ngram-mod --spec-draft-p-min 0.85 --spec-draft-n-max 4 \
+  --spec-ngram-mod-n-match 24 --spec-ngram-mod-n-min 8 --spec-ngram-mod-n-max 16
+```
+
+Our stock build (b9850) supports the comma-list `--spec-type` and the `--spec-ngram-mod-*` flags.
+`ngram-mod` proposes drafts by matching the **generated suffix against the context history** — so
+it only helps when the model **echoes** its input (large diffs, "return the whole file", refactors,
+boilerplate), and does nothing for freshly-generated prose/logic. To expose that, `mtp-bench.py`
+grew a `--prompt code` mode (an echo-heavy "reproduce this module verbatim" prompt) alongside the
+default generative `summary` prompt, plus a `--spec-type` override. A/B on `coding`
+(Qwen3.6-27B Q6_K, V100 idx1, ctx 40960, q8_0 KV, 512-tok gens, temp 0) — **decode tok/s (accept%)**:
+
+| prompt | size | off | `draft-mtp` n2 (shipped) | `draft-mtp` n4 | `draft-mtp,ngram-mod` n4 |
+|--------|-----:|----:|-------------------------:|---------------:|-------------------------:|
+| **code** (echo-heavy) | ~5k  | 21.8 | 42.6 (100%) | 53.2 (100%) | **64.9 (74%)** |
+| **code** (echo-heavy) | ~21k | 20.1 | 38.8 (100%) | 48.3 (100%) | **58.2 (73%)** |
+| summary (generative)  | ~4k  |  —   | 40.6 (86%)  | 47.3 (82%)  | **32.1 (66%)** |
+| summary (generative)  | ~16k |  —   | 41.4 (100%) | 44.0 (82%)  | 51.4 (92%)† |
+
+**Takeaways:**
+- **On echo-heavy coding, `ngram-mod` is a genuine, isolated win.** Separating it from the
+  `n_max` 2→4 bump: ngram adds **+22 % over `draft-mtp` n4** and **+52 % over the shipped n2**
+  (**+198 % vs off**) at ~5k, holding to +50 %/+20 % at ~21k. `ngram-mod` proposes long verbatim
+  spans that get accepted in bulk, so per-token accept **drops** (74 %) while throughput jumps —
+  accept% is misleading here; look at tok/s.
+- **It can hurt pure generative short-context** (−32 % vs `draft-mtp` n4 @4k summary): with no echo
+  to match, rejected n-gram drafts waste decode steps. († the 16k "gain" is an artifact of the
+  synthetic filler prompt degenerating into repetition, which `ngram-mod` then matches — not a real
+  generative win.)
+- **Side finding:** simply raising MTP `n_max` **2→4** helped *both* workloads unconditionally
+  (+25 % code, +16 % generative @4k) for **+0.3 GB** VRAM — a lower-risk lever independent of ngram.
+- The suggested `--cache-type-k-draft/v-draft q4_0` are **no-ops for this slot** — they quantize a
+  *separate draft model's* KV cache, but `coding` uses an **embedded** MTP head + the model-free
+  `ngram-mod`, so there is no draft-model KV to quantize. Omitted here.
+
+**Decision:** the daily `coding` slot serves a **mix** of echo and generative work, so blanket
+`ngram-mod` is not shipped (risks ~30 % regressions on generative turns). It's best as an **opt-in
+for edit/refactor-heavy sessions** (candidate: a `coding-edit` mode overlay). The unconditional
+`n_max` 2→4 bump is a separate candidate worth validating on the full 500→32k sweep before shipping.
+
+Data: `docs/data/mtp/coding-ngram-hybrid.csv`. Reproduce:
+
+```bash
+M=models/qwen3.6-27b-mtp/Qwen3.6-27B-Q6_K.gguf
+# echo-heavy code prompt: off + shipped MTP n2 + deeper n4
+python3 scripts/mtp-bench.py --model $M --gpu 1 --ctx 40960 --ubatch 2048 \
+  --prompt code --sizes 4096,16384 --gen 512 --nmax 0 2 4 --label coding-code --no-restore
+# hybrid: ngram-mod ahead of MTP
+python3 scripts/mtp-bench.py --model $M --gpu 1 --ctx 40960 --ubatch 2048 \
+  --prompt code --sizes 4096,16384 --gen 512 --nmax 4 --label coding-code --no-restore \
+  --spec-type "draft-mtp,ngram-mod" \
+  --extra "--spec-draft-p-min 0.85 --spec-ngram-mod-n-match 24 --spec-ngram-mod-n-min 8 --spec-ngram-mod-n-max 16"
+```
 
 ### MTP on the `big` model — Qwen3.6-27B UD-Q6_K_XL, **dual-V100 split** (2026-07-23)
 

--- a/docs/data/mtp/coding-ngram-hybrid.csv
+++ b/docs/data/mtp/coding-ngram-hybrid.csv
@@ -1,0 +1,15 @@
+prompt,config,nmax,spec_type,prompt_tokens,ttft_s,prefill_tok_s,decode_tok_s,accept_pct,vram_mib
+code,off,0,none,5100,6.166,852.0,21.8,,23886
+code,off,0,none,20827,27.419,760.6,20.1,,23886
+code,mtp-n2,2,draft-mtp,5100,6.599,795.0,42.6,100.0,25146
+code,mtp-n2,2,draft-mtp,20827,29.679,703.5,38.8,100.0,25146
+code,mtp-n4,4,draft-mtp,5100,6.562,799.5,53.2,100.0,25446
+code,mtp-n4,4,draft-mtp,20827,28.963,720.0,48.3,100.0,25446
+code,mtp+ngram-n4,4,"draft-mtp,ngram-mod",5100,6.596,794.5,64.9,74.2,25448
+code,mtp+ngram-n4,4,"draft-mtp,ngram-mod",20827,29.267,712.7,58.2,73.4,25448
+summary,mtp-n2,2,draft-mtp,4091,5.275,805.2,40.6,86.4,25146
+summary,mtp-n2,2,draft-mtp,16376,22.096,743.1,41.4,100.0,25146
+summary,mtp-n4,4,draft-mtp,4091,5.248,807.6,47.3,82.1,25446
+summary,mtp-n4,4,draft-mtp,16376,21.945,748.1,44.0,82.1,25446
+summary,mtp+ngram-n4,4,"draft-mtp,ngram-mod",4091,5.235,808.9,32.1,65.6,25448
+summary,mtp+ngram-n4,4,"draft-mtp,ngram-mod",16376,21.859,751.0,51.4,92.3,25448

--- a/scripts/mtp-bench.py
+++ b/scripts/mtp-bench.py
@@ -61,6 +61,35 @@ def make_prompt(approx_tokens):
             "\n\nSummary:")
 
 
+# Echo-heavy coding prompt: the model must reproduce a whole module verbatim while
+# inserting one novel line per function. Most output tokens match the context, so
+# the model-free ngram-mod drafter can propose long verbatim spans (draft-mtp
+# handles the few novel tokens). This is the scenario where `ngram-mod` before
+# `draft-mtp` is expected to help — unlike the summary prompt above, where the
+# generated text does NOT echo the input.
+_CODE_FN = (
+    'def process_item_{i}(record, config, logger):\n'
+    '    """Validate and transform a single record."""\n'
+    '    if record is None:\n'
+    '        logger.warning("null record at index %d", {i})\n'
+    '        return None\n'
+    '    value = record.get("value", 0) * config.scale + config.offset\n'
+    '    if value > config.threshold:\n'
+    '        logger.info("item {i} exceeds threshold: %s", value)\n'
+    '    return {{"id": record["id"], "value": value, "ok": True}}\n\n')
+
+
+def make_code_prompt(approx_tokens):
+    reps = max(1, approx_tokens // 90)
+    body = "".join(_CODE_FN.format(i=i) for i in range(reps))
+    return ("Below is a Python module. Return the COMPLETE module verbatim, but insert the "
+            "line `    # validated` as the first line inside each function body. Output only "
+            "the code, no commentary.\n\n```python\n" + body + "```\n")
+
+
+PROMPT_FNS = {"summary": make_prompt, "code": make_code_prompt}
+
+
 def swap_unload_all():
     for path in ("/unload", "/api/unload"):
         try:
@@ -99,6 +128,7 @@ SPLIT = False          # --split-mode layer across multiple GPUs (dual-V100 big)
 DRAFT_MODEL = None     # separate draft-model GGUF (Gemma-4 assistant MTP); set via --draft-model
 UBATCH = None          # override ubatch (defaults to BATCH); set via --ubatch
 EXTRA = []             # extra passthrough flags (e.g. --reasoning-budget 0); set via --extra
+SPEC_TYPE = "draft-mtp"  # speculative decode type; set via --spec-type (e.g. "draft-mtp,ngram-mod")
 
 
 def build_cmd(nmax, ctx=CTX):
@@ -110,7 +140,7 @@ def build_cmd(nmax, ctx=CTX):
     if SPLIT:
         cmd += ["--split-mode", "layer"]
     if nmax > 0:
-        cmd += ["--spec-type", "draft-mtp", "--spec-draft-n-max", str(nmax)]
+        cmd += ["--spec-type", SPEC_TYPE, "--spec-draft-n-max", str(nmax)]
         if DRAFT_MODEL:
             cmd += ["--model-draft", DRAFT_MODEL, "--n-gpu-layers-draft", "99"]
     cmd += EXTRA
@@ -197,7 +227,7 @@ def accept_rate(tim):
 
 
 def main():
-    global MODEL, GPU, KV_TYPE, SPLIT, DRAFT_MODEL, UBATCH, EXTRA
+    global MODEL, GPU, KV_TYPE, SPLIT, DRAFT_MODEL, UBATCH, EXTRA, SPEC_TYPE, GEN_TOKENS
     ap = argparse.ArgumentParser()
     ap.add_argument("--nmax", type=int, nargs="+", default=[0, 1, 2, 3, 4],
                     help="MTP n_max values to test; 0 = baseline (MTP off)")
@@ -215,6 +245,14 @@ def main():
                          "when set, MTP uses --model-draft instead of an embedded head")
     ap.add_argument("--ubatch", type=int, default=None, help="override ubatch size (default = batch)")
     ap.add_argument("--extra", default="", help="extra passthrough flags, space-separated (e.g. '--reasoning-budget 0')")
+    ap.add_argument("--spec-type", default="draft-mtp",
+                    help="speculative decode type passed to --spec-type (e.g. 'draft-mtp,ngram-mod')")
+    ap.add_argument("--prompt", choices=list(PROMPT_FNS), default="summary",
+                    help="prompt shape: 'summary' (generative, ngram-unfavorable) or "
+                         "'code' (echo-heavy, ngram-favorable)")
+    ap.add_argument("--sizes", default="",
+                    help="comma list of prompt sizes to sweep, overriding the default 500-32k set")
+    ap.add_argument("--gen", type=int, default=GEN_TOKENS, help="tokens to generate per probe")
     ap.add_argument("--label", default="qwen35-chat",
                     help="model label: names the CSV (<label>-mtp.csv) and the 'model' column")
     ap.add_argument("--no-restore", action="store_true")
@@ -223,8 +261,14 @@ def main():
     KV_TYPE, SPLIT = a.kv, a.split
     DRAFT_MODEL, UBATCH = a.draft_model, a.ubatch
     EXTRA = a.extra.split() if a.extra else []
+    SPEC_TYPE = a.spec_type
+    GEN_TOKENS = a.gen
+    prompt_fn = PROMPT_FNS[a.prompt]
     ctx = a.ctx
-    sizes = [a.fill] if a.fill else PROMPT_SIZES
+    if a.sizes:
+        sizes = [int(s) for s in a.sizes.split(",")]
+    else:
+        sizes = [a.fill] if a.fill else PROMPT_SIZES
 
     os.makedirs(DATA_DIR, exist_ok=True)
     out = (f"{DATA_DIR}/{a.label}-mtp-ctxfit.csv" if a.fill
@@ -255,11 +299,11 @@ def main():
                                          capture_output=True, text=True).stdout)
                     continue
                 print(f"ready; weights+ctx VRAM ~{vram_used(GPU)} MiB", flush=True)
-                probe(make_prompt(128), 16)  # warm
+                probe(prompt_fn(128), 16)  # warm
                 for sz in sizes:
                     if sz + GEN_TOKENS + 256 > ctx:
                         print(f"  prompt~{sz}: skipped (exceeds ctx {ctx})"); continue
-                    ttft, tim = probe(make_prompt(sz), GEN_TOKENS)
+                    ttft, tim = probe(prompt_fn(sz), GEN_TOKENS)
                     if ttft is None:
                         print(f"  prompt~{sz}: probe failed"); continue
                     pn = tim.get("prompt_n", 0)


### PR DESCRIPTION
Tests a community suggestion to chain a model-free n-gram drafter ahead of MTP (`--spec-type draft-mtp,ngram-mod`) on the coding slot.

## Results (coding, Qwen3.6-27B Q6_K, V100 idx1, decode tok/s)
| prompt | size | off | MTP n2 | MTP n4 | MTP+ngram n4 |
|--------|-----:|----:|-------:|-------:|-------------:|
| code (echo) | ~5k | 21.8 | 42.6 | 53.2 | **64.9** |
| code (echo) | ~21k | 20.1 | 38.8 | 48.3 | **58.2** |
| summary (gen) | ~4k | — | 40.6 | 47.3 | **32.1** ⬇ |

## Takeaways
- ngram-mod is a real win for **echo-heavy coding** (+22% over MTP n4, +52% over shipped n2) but **hurts generative short-context** (~-32%).
- Bumping MTP n_max 2→4 helps both workloads unconditionally (+0.3GB) — separate candidate.
- Not shipping ngram-mod on the mixed daily coding slot; documented as opt-in for edit/refactor sessions.
- Suggested `--cache-type-*-draft` flags are no-ops for the embedded-MTP slot.

Harness: `mtp-bench.py` gains `--spec-type`, `--prompt {summary,code}`, `--sizes`, `--gen` (backward-compatible).