### PR TITLE
models: cold-tier symlink to 1TB bulk drive

### DIFF
--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -245,7 +245,11 @@ less fragile and engines independently upgradable.
    media; (c) **unsecured bulk** Seagate 1TB (ext4 `LABEL=aibulk` →
    `/srv/ai/storage-bulk`, fstab `defaults,nofail`) for model weights and other large
    non-secret data. Prefer `/srv/ai/storage-bulk` for big model downloads to keep `/`
-   free.
+   free. **Model cold-tier:** `/srv/ai/models/cold` is a symlink →
+   `/srv/ai/storage-bulk/models` — hot/served model dirs stay directly under
+   `/srv/ai/models/`; rarely-used, base-weight, or superseded-quant dirs (e.g. the plain
+   `qwen3.6-27b/` BF16+non-MTP quants, `pxq-fusion4/`, `qwen3.5-9b/`) live under
+   `/srv/ai/models/cold/` on the 1TB. Nothing in `llama-swap.base.yaml` references `cold/`.
 
 ---
 

--- a/scripts/power-cap-sweep.sh
+++ b/scripts/power-cap-sweep.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 
 GPU=${GPU:-1}
 CAPS=(${CAPS:-250 200 175 150})
-MODEL=${MODEL:-$(ls /srv/ai/models/qwen3.6-27b/*Q6_K*.gguf 2>/dev/null | head -1)}
+MODEL=${MODEL:-$(ls /srv/ai/models/cold/qwen3.6-27b/*Q6_K*.gguf /srv/ai/models/qwen3.6-27b-mtp/*Q6_K*.gguf 2>/dev/null | head -1)}
 BIN=${BIN:-/srv/ai/src/llama.cpp/build/bin/llama-bench}
 NGL=${NGL:-999}                 # GPU layers to offload (lower for a tight-fit card)
 PP=${PP:-2048}                  # prefill tokens


### PR DESCRIPTION
Offload cold/base/superseded model dirs to the new 1TB bulk drive via a `/srv/ai/models/cold` symlink.

- `/srv/ai/models/cold` -> `/srv/ai/storage-bulk/models`
- Moved `qwen3.6-27b` (144G BF16 base + non-MTP quants, superseded by `qwen3.6-27b-mtp`), `pxq-fusion4`, `qwen3.5-9b`
- Root NVMe freed: **92% -> 75%** (275G free)
- `power-cap-sweep.sh` default MODEL path updated
- Documented cold-tier in server-setup.md

Nothing in `llama-swap.base.yaml` references `cold/` — all served slots use hot dirs.