### PR TITLE
comfyui-mcp: keep bridge up (degraded) when ComfyUI is down — fixes mcpo boot spin

### DIFF
--- a/scripts/comfyui-mcp-launch.py
+++ b/scripts/comfyui-mcp-launch.py
@@ -19,13 +19,34 @@ Config via env (see comfyui-mcp.service):
 """
 import os
 import sys
+import time
 
 SRC = os.getenv("COMFY_MCP_SRC", "/srv/ai/src/comfyui-mcp-server")
 sys.path.insert(0, SRC)
 # publish-root detection uses cwd; run from the repo root like upstream expects.
 os.chdir(SRC)
 
-import server  # noqa: E402  (module-level ComfyUI availability check runs on import)
+# Upstream server.py runs a ComfyUI availability check at *import* time and calls
+# sys.exit(1) if ComfyUI is unreachable. That makes the bridge (and its :9000
+# endpoint) disappear whenever ComfyUI is intentionally down — e.g. the quiet-hours
+# window stops comfyui-open/secure to free the V100 overnight. When the bridge is
+# gone, mcpo's "comfyui" streamable-http upstream fails to initialise at startup,
+# which cancels mcpo's whole lifespan and leaves it spinning a CPU core at 100%
+# (taking the healthy stdio tools down with it).
+#
+# To keep :9000 reachable at all times, start the bridge in a *degraded* mode when
+# ComfyUI is down: neutralise the import-time hard-exit (and skip its retry sleeps)
+# so the FastMCP server still comes up and serves the tool list. Tool *calls* will
+# fail until ComfyUI returns, but mcpo connects cleanly and stays healthy. When
+# ComfyUI comes back, calls succeed again (the client connects per request). This
+# keeps the upstream clone pristine — no fork required.
+_orig_exit, _orig_sleep = sys.exit, time.sleep
+sys.exit = lambda *a, **k: None        # let module load past the availability guard
+time.sleep = lambda *a, **k: None      # don't block on the 5-attempt backoff
+try:
+    import server  # noqa: E402  (module-level ComfyUI availability check runs on import)
+finally:
+    sys.exit, time.sleep = _orig_exit, _orig_sleep
 
 server.mcp.settings.host = os.getenv("FASTMCP_HOST", "0.0.0.0")
 _port = os.getenv("FASTMCP_PORT", "").strip()


### PR DESCRIPTION
## Problem
mcpo pegs a CPU core at 100% after every reboot that lands inside the quiet-hours window.

## Root cause
Quiet-hours (02:00–09:00 `America/New_York`, in `server-status-service.py`) intentionally stops `comfyui-open`/`comfyui-secure` to free the V100 overnight. The vendored `comfyui-mcp-server/server.py` runs a ComfyUI availability check **at import time** and `sys.exit(1)`s if ComfyUI is unreachable, so the `:9000` bridge never comes up. mcpo's `comfyui` streamable-http upstream then fails to initialise during `create_dynamic_endpoints`, which **cancels mcpo's entire lifespan** and leaves it spinning — taking the healthy stdio tools (time/fetch/git/plan-build) down with it ("MCP session is not available").

The prior fix (uv-cache + healthcheck + autoheal, PR #18/#19) targeted a *different* failure mode (uvx stdio zombies) and didn't address this.

## Fix
`comfyui-mcp-launch.py` now neutralises the import-time hard-exit (and skips the retry backoff sleeps) so the FastMCP bridge still binds `:9000` and serves the tool list when ComfyUI is down. Tool *calls* fail until ComfyUI returns; mcpo connects cleanly and stays healthy. Upstream clone stays pristine (no fork).

## Verified live (during quiet hours, ComfyUI down)
- bridge `:9000` → HTTP 406 (up) instead of exiting
- mcpo `healthy`, **0.14% CPU**, 0 zombies
- mcpo logs: all 6 upstreams connected incl. `comfyui`
- time tool returns correct JSON
- No regression when ComfyUI is up (patches only active during import; availability check passes immediately, hard-exit never reached).