### PR TITLE
docs: keep agentic coding Q6_K hot; note mode-overlay cold-move gotcha

### DIFF
--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -248,8 +248,12 @@ less fragile and engines independently upgradable.
    free. **Model cold-tier:** `/srv/ai/models/cold` is a symlink →
    `/srv/ai/storage-bulk/models` — hot/served model dirs stay directly under
    `/srv/ai/models/`; rarely-used, base-weight, or superseded-quant dirs (e.g. the plain
-   `qwen3.6-27b/` BF16+non-MTP quants, `pxq-fusion4/`, `qwen3.5-9b/`) live under
-   `/srv/ai/models/cold/` on the 1TB. Nothing in `llama-swap.base.yaml` references `cold/`.
+   `qwen3.6-27b/` BF16 + `Q4_K_M`/`UD-Q6_K_XL`/`UD-Q8_K_XL` quants, `pxq-fusion4/`,
+   `qwen3.5-9b/`) live under `/srv/ai/models/cold/` on the 1TB. **Gotcha:** check the mode
+   overlays (`config/modes/*.yaml`), not just `llama-swap.base.yaml`, before cold-moving a
+   file — the `agentic` overlay pins `coding` to the non-MTP `qwen3.6-27b/Qwen3.6-27B-Q6_K.gguf`,
+   so that one file is kept hot (only the base/superseded quants above go cold). Nothing in
+   `llama-swap.base.yaml` references `cold/`.
 
 ---
 


### PR DESCRIPTION
Fixes a regression from this session's model cold-storage move: it relocated `qwen3.6-27b/` (including the non-MTP `Qwen3.6-27B-Q6_K.gguf`) to the 1TB cold tier, but the `agentic` mode overlay pins its `coding` slot to `${models_dir}/qwen3.6-27b/Qwen3.6-27B-Q6_K.gguf`. That file was moved back to hot NVMe; the base/superseded quants (BF16, Q4_K_M, UD-Q6_K_XL, UD-Q8_K_XL) stay cold.

Documents the gotcha: check `config/modes/*.yaml` (not just `llama-swap.base.yaml`) before cold-moving model files.

No code/config change — the overlay already expected the hot path; this restores it and updates the storage-layout note.