### PR TITLE
P100 HBM ECC death: Titan X stopgap (config, fan-control, ADR-0017)

### DIFF
--- a/config/llama-swap.base.yaml
+++ b/config/llama-swap.base.yaml
@@ -198,23 +198,33 @@ models:
   # model is loaded, so we max VRAM. See docs/benchmarking.md "MTP on the `fast`
   # model". NB: MTP is single-stream only — the agentic/heavy-coding overlays run
   # `fast` at --parallel 2 and strip the draft (spec: none).
+  # TEMPORARY (2026-07-27): the P100 (idx0) failed with an uncorrectable HBM
+  # double-bit ECC error (Xid 48/64/62, page-retirement fatal, "GPU Reset
+  # Required") and was replaced by a stopgap 12GB GTX TITAN X (Maxwell sm_52).
+  # The 26B MoE UD-Q4_K_XL (~15.9GB) does NOT fit 12GB, so `fast` temporarily
+  # serves the dense 12B (~6.3GB, fits with comfortable headroom). RESTORE the
+  # MoE block below when a 16GB+ card (P100/V100) returns to idx0.
+  #   --model ${models_dir}/gemma-4-26b-a4b/gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf
+  #   --batch-size 2048 --ubatch-size 1024
+  #   --model-draft ${models_dir}/gemma-4-26b-a4b/mtp-draft/gemma-4-26B-A4B-it-assistant-Q8_0.gguf
+  # NB: the MTP draft (--spec-type draft-mtp) CRASHES on the Maxwell Titan X with a
+  # CUDA illegal-memory-access in common_speculative_impl_draft_mtp::draft (the
+  # draft ctx also fails to init: "Gemma4Assistant requires ctx_other to be set").
+  # So the draft is STRIPPED on all three idx0 models during the stopgap (slower
+  # decode, but it actually serves). RESTORE the draft lines with the 16GB+ card.
   "fast":
-    name: "Gemma-4-26B-A4B (MoE + MTP) — fast non-reasoning chat"
-    description: "Snappy general chat on the P100 (MoE, ~3.8B active); no reasoning phase, MTP self-spec decode. Always available."
+    name: "Gemma-4-12B dense — fast non-reasoning chat (TITAN X stopgap)"
+    description: "Snappy general chat on the stopgap 12GB Titan X (idx0); dense 12B, no reasoning phase. Temporary replacement for the failed P100's 26B MoE. MTP draft disabled (crashes on Maxwell)."
     env:
       - "CUDA_DEVICE_ORDER=PCI_BUS_ID"
       - "CUDA_VISIBLE_DEVICES=0"
     cmd: |
       ${llama-server}
-      --model ${models_dir}/gemma-4-26b-a4b/gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf
+      --model ${models_dir}/gemma-4-12b/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf
       --ctx-size 32768
       --parallel 1
-      --batch-size 2048 --ubatch-size 1024
+      --batch-size 2048 --ubatch-size 2048
       --reasoning-budget 0
-      --model-draft ${models_dir}/gemma-4-26b-a4b/mtp-draft/gemma-4-26B-A4B-it-assistant-Q8_0.gguf
-      --spec-type draft-mtp
-      --spec-draft-n-max 1
-      --n-gpu-layers-draft 99
       ${common}
 
   # --- fast-12b: Gemma-4-12B dense (QAT UD-Q4_K_XL) on the P100 (idx0) -----
@@ -231,9 +241,14 @@ models:
   # costs ~0.8GB (~9.8GB/16GB at 32k) so 128k headroom is unaffected. See
   # docs/benchmarking.md "MTP on the `fast-12b` model". Always --parallel 1 (no
   # overlay overrides it), so MTP applies in every mode.
+  # TEMPORARY (2026-07-27): idx0 is the 12GB GTX Titan X stopgap (P100 died, ECC).
+  # 128k ctx OOMs on 12GB (weights 6.3GB + 128k KV > 12GB), so ctx is dropped to
+  # 32768. The MTP draft (--spec-type draft-mtp) also CRASHES on the Maxwell Titan
+  # X (CUDA illegal memory access in the draft sampler), so it is STRIPPED here.
+  # RESTORE --ctx-size 131072 + the draft lines when a 16GB+ card returns to idx0.
   "fast-12b":
-    name: "Gemma-4-12B dense (MTP) — fast fallback (headroom)"
-    description: "Dense 12B fallback on the P100; more VRAM headroom (128k ctx) than the MoE `fast`, MTP self-spec decode. Shares idx0 (mutually exclusive)."
+    name: "Gemma-4-12B dense — fast fallback (headroom)"
+    description: "Dense 12B fallback on the idx0 Titan X stopgap. Shares idx0 (mutually exclusive). Ctx 32k, MTP draft disabled (crashes on Maxwell)."
     ttl: 600
     env:
       - "CUDA_DEVICE_ORDER=PCI_BUS_ID"
@@ -241,14 +256,10 @@ models:
     cmd: |
       ${llama-server}
       --model ${models_dir}/gemma-4-12b/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf
-      --ctx-size 131072
+      --ctx-size 32768
       --parallel 1
       --batch-size 2048 --ubatch-size 2048
       --reasoning-budget 0
-      --model-draft ${models_dir}/gemma-4-12b/mtp-draft/gemma-4-12B-it-qat-assistant-MTP-Q8_0.gguf
-      --spec-type draft-mtp
-      --spec-draft-n-max 1
-      --n-gpu-layers-draft 99
       ${common}
 
   # --- fast-uncensored: Gemma-4-12B QAT Uncensored (Balanced Q4_K_M) on P100 -
@@ -260,9 +271,16 @@ models:
   # Vision via --mmproj; MTP speculative decoding (Unsloth draft head) for ~60%
   # faster generation with identical output. Tuned sampling per the model card.
   # ttl unloads it so `fast` reclaims the card.
+  # TEMPORARY (2026-07-27): idx0 is the 12GB GTX Titan X stopgap (P100 died, ECC).
+  # 128k ctx OOMs on 12GB, so ctx dropped to 32768. This tune also loads a BF16
+  # mmproj (vision) on top of ~7.4GB Q4_K_M weights, so it is the tightest of the
+  # idx0 models on 12GB — watch for OOM. The MTP draft (--spec-type draft-mtp) also
+  # CRASHES on the Maxwell Titan X (CUDA illegal memory access in the draft
+  # sampler), so it is STRIPPED here. RESTORE --ctx-size 131072 + the draft lines
+  # when a 16GB+ card returns to idx0.
   "fast-uncensored":
-    name: "Gemma-4-12B Uncensored — reasoning chat + vision (MTP)"
-    description: "Uncensored/abliterated Gemma-4-12B on the P100; reasoning on, vision (mmproj), MTP speculative decoding. Shares idx0 with fast (mutually exclusive)."
+    name: "Gemma-4-12B Uncensored — reasoning chat + vision"
+    description: "Uncensored/abliterated Gemma-4-12B on the idx0 Titan X stopgap; reasoning on, vision (mmproj). Shares idx0 with fast (mutually exclusive). Ctx 32k, MTP draft disabled (crashes on Maxwell)."
     ttl: 600
     env:
       - "CUDA_DEVICE_ORDER=PCI_BUS_ID"
@@ -271,10 +289,7 @@ models:
       ${llama-server}
       --model ${models_dir}/gemma-4-12b-uncensored/Gemma4-12B-QAT-Uncensored-HauhauCS-Balanced-Q4_K_M.gguf
       --mmproj ${models_dir}/gemma-4-12b-uncensored/mmproj-Gemma4-12B-QAT-Uncensored-HauhauCS-Balanced-BF16.gguf
-      --model-draft ${models_dir}/gemma-4-12b-uncensored/mtp-gemma-4-12B-it.gguf
-      --spec-type draft-mtp
-      --n-gpu-layers-draft 99
-      --ctx-size 131072
+      --ctx-size 32768
       --parallel 1
       --batch-size 2048 --ubatch-size 2048
       --temp 0.6 --top-k 64 --top-p 0.9 --min-p 0.05 --repeat-penalty 1.1

--- a/docs/adr/0017-p100-hbm-ecc-death-titan-x-stopgap.md
+++ b/docs/adr/0017-p100-hbm-ecc-death-titan-x-stopgap.md
@@ -1,0 +1,125 @@
+# ADR-0017 — P100 HBM2 ECC death: diagnosis and Titan X stopgap swap
+
+* Status: Accepted
+* Date: 2026-07-27
+* Deciders: @bradrlaw (+ Copilot CLI)
+
+## Context
+
+The Tesla P100-16GB (idx0, bus01, sm_60) that served the `fast` / `fast-uncensored`
+carve-out (ADR-0014) died from an **uncorrectable HBM2 memory failure**. The
+symptoms first looked like a software/driver regression, so the diagnosis path is
+worth recording — the failure mode wedges the *entire* NVIDIA stack, not just the
+bad card.
+
+UUID `GPU-d85ec299-860f-c3e8-1546-64c7d79a2b47`, board serial `0322417146308`.
+
+### Symptoms (in the order they appeared)
+1. `nvidia-smi dmon` / the fan-control and status-page pollers pegged a CPU core;
+   system load climbed to ~7 and the box felt sluggish.
+2. Every new `nvidia-smi` invocation hung in uninterruptible `D` state and stacked
+   up; the status page showed the two V100s as "unavailable".
+3. gpu-fan-control log: `power cap GPU0 -> 200W FAILED ... Unknown Error`;
+   `power.draw` for idx0 read `[Unknown Error]` while temp/limit still read fine.
+4. A monitoring `nvidia-smi` appeared to "respawn" — actually the timer-driven
+   status-page poller re-launching, each instance hanging on the dead card.
+
+### Root cause (confirmed via dmesg after a reboot)
+```
+Xid 62  — GPU microcontroller (µC) halt
+Xid 48  — uncorrectable double-bit ECC error (DBE) in framebuffer, partition 1/1
+Xid 171 — HBM, uncorrectable DRAM error in FBPA 1 subpartition 1
+Xid 64  — Dynamic Page Retirement: FATAL, unable to retire page (0x3fdf5e)
+Xid 154 — GPU recovery action changed None -> "GPU Reset Required"
+```
+The HBM2 took a double-bit error at a physical address the driver then **could not
+retire** (retirement table full/failed), which halted the on-die microcontroller.
+With the µC halted, NVML can no longer talk to the card: `power.draw` returns
+`Unknown Error`, and because NVML holds a **global lock**, one wedged GPU makes
+*every* `nvidia-smi` / `cuInit` on the system hang — hence the CPU spin, the load
+climb, and the V100s appearing "unavailable" even though they were fine.
+
+### Why it was NOT the driver / cooling (ruled out during triage)
+* **Driver:** an unattended-upgrade on 2026-07-25 had bumped NVIDIA 580.159.03 →
+  580.173.02, which looked like a smoking gun. But per-boot fan-control logs proved
+  the P100 ran clean on 580.173.02 for two days (including the morning of the
+  failure); "Unknown Error" first appeared only at a later reboot. Same driver
+  before and after ⇒ not a software regression. (Auto-updates have since been
+  disabled and the driver `apt-mark hold`ed regardless — see the auto-update memory.)
+* **Cooling:** our thermals were fine. The P100 never throttled — it settled
+  ~70-75 °C at the 200 W cap with the pump-fan curve, ~15 °C under limit, and the
+  fan was operating normally right up to the failure. (When physically pulled the
+  card was quite hot to the touch, but that is post-mortem heat soak, not a cooling
+  regression — the sensor/curve data show no thermal event.) This was a **silicon
+  HBM failure**, not a thermal one.
+
+### Why a reset couldn't fix it
+`nvidia-smi -r -i 0` requires a live microcontroller to accept the reset. Xid 62
+means the µC is already halted, so the reset itself hangs. The halted state lives
+in-silicon and survives reboots, reseats, and full power-cuts — reseating the card
+and re-seating every power connector changed nothing. The card is not recoverable.
+
+## Decision
+
+1. **Retire the P100** as failed hardware.
+2. **Install a 12 GB GTX Titan X (Maxwell, sm_52)** into the same bus01 slot as a
+   temporary stopgap so the server keeps three GPUs and the `fast` slot stays alive.
+3. **Rebuild llama.cpp for the arch superset `52;60;61;70`** (was `60;70`) so the
+   same binary still runs a future P100/V100 *and* the Maxwell Titan X. The prior
+   working `60;70` build is preserved at
+   `src/llama.cpp/build.bak-sm60_70-4f31eedb0-20260727/` for when a passive card
+   returns.
+4. **Repoint the `fast` slot** from the 16 GB Gemma-4-26B-A4B MoE to the dense
+   **Gemma-4-12B** (Q4_K_XL, 32k ctx) so it fits the Titan X's 12 GB. The MoE
+   block is preserved commented-out in `config/llama-swap.base.yaml` for restore.
+   LiteLLM's `fast` entry is unchanged (same model id), so no gateway edit. The
+   other two idx0 models (`fast-12b`, `fast-uncensored`) were likewise dropped
+   from 128k ctx to 32k (128k OOMs on 12 GB).
+   **The MTP speculative draft (`--spec-type draft-mtp`) was stripped from all
+   three idx0 models** — it crashes on the Maxwell Titan X with a CUDA illegal
+   memory access in `common_speculative_impl_draft_mtp::draft` (the draft context
+   also fails to initialise: "Gemma4Assistant requires ctx_other to be set"). The
+   crash only appears on a real completion request, not at model load / health
+   check, which is why the initial `llama-bench` smoke test (no draft) missed it
+   and the symptom was "GPU activity in Open WebUI but no output". Without the
+   draft the models serve correctly (just slower decode).
+5. **Adapt gpu-fan-control** for the Titan X: it cools itself with its own
+   built-in fan (readable via `nvidia-smi fan.speed`, unlike the passive
+   P100/V100 which report `N/A`) and does **not** use the chassis PUMP_FAN. So the
+   idx0 zone is made **`monitor_only`**: the daemon logs the card's temp and its
+   own fan duty (as `gpufan%`) but drives no chassis PWM, and hands the old P100
+   pump-fan header (pwm1) back to BIOS auto at startup so we stop forcing an unused
+   fan. The V100 zones are unchanged.
+
+## Consequences
+
+* Positive: server stays fully operational on three GPUs; `coding`+`chat` on the
+  V100s are untouched; the `fast` slot still serves (12B on the Titan X:
+  ~pp128 88 t/s / tg32 23 t/s, 12.2 GB VRAM). One binary now covers Maxwell→Volta.
+* Negative / trade-offs: the Titan X is slower than the P100 was and only 12 GB, so
+  `fast` dropped from the 26B MoE @ 128k ctx to a 12B dense @ 32k ctx. It is a
+  consumer Maxwell card (no ECC, older, no ADR-0014 fp16 accuracy patch relevance).
+  The `big` dual-V100 model lost its NCCL build during the rebuild (minor; single-
+  GPU models unaffected) — revisit if `big` matters.
+* Follow-ups / things to watch:
+  - When a 16 GB+ passive card (another P100, or a V100) returns to idx0: restore
+    the MoE `fast` block, revert the fan-zone label/curve, and optionally rebuild
+    off `build.bak-sm60_70-...`. Re-enable NCCL if `big` is wanted.
+  - Operational lesson: a single wedged GPU hangs the *whole* NVML stack. If
+    `nvidia-smi` hangs and `power.draw` reads `Unknown Error` on one card, suspect
+    that card's silicon (check dmesg for Xid 48/62/64/171/154) and physically pull
+    it — don't chase drivers or the pollers.
+  - Maxwell (sm_52) lesson: the `draft-mtp` speculative-decode path CUDA-faults on
+    the Titan X, and only on a real request (load/health pass first). Validate a
+    new GPU with an actual streaming completion through the router, not just
+    `llama-bench` — a bench without the draft/serving path gives a false pass.
+
+## Alternatives considered
+* **RMA / repair the P100** — out of warranty, used Volta-era datacenter card;
+  HBM is not field-serviceable. Rejected.
+* **Run headless on two V100s only** — would drop the `fast` P100 carve-out
+  entirely and leave idx0 empty; the Titan X was on hand and keeps the slot warm
+  for testing. Rejected in favour of the stopgap.
+* **Buy a replacement immediately** — the user may choose another P100 or a third
+  V100 later; the stopgap + preserved build + preserved MoE config make that a
+  clean swap-back without blocking on a purchase now.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,7 @@ sessions) don't re-litigate settled choices or lose the reasoning behind them.
 | [0014](0014-p100-fast-fp16-carveout.md) | Patch llama.cpp to disable FAST_FP16 on the Tesla P100 (sm_60) | Accepted |
 | [0015](0015-llama-swap-serving-modes.md) | llama-swap serving modes (base + overlay) | Accepted |
 | [0016](0016-personal-assistant-gateways.md) | Personal-assistant gateway layer (OpenClaw + Hermes) | Accepted |
+| [0017](0017-p100-hbm-ecc-death-titan-x-stopgap.md) | P100 HBM2 ECC death: diagnosis + Titan X stopgap swap | Accepted |
 
 ## Template
 Copy [`template.md`](template.md) for new records.

--- a/scripts/gpu-fan-control.config.json
+++ b/scripts/gpu-fan-control.config.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "GPU shroud fan control. Curves mirror the user's proven Windows FanControl setup. CONTROL INPUT = max(core, HBM memory) temp: on the V100 the HBM2 memory runs ~15-20C hotter than the core and throttles at ~85C, so the fan is driven off memory temp (P100 reports no memory temp -> uses core). Wiring/pwm verified: pwm5=V100 GPU1(bus03), pwm4=V100 GPU2(bus04), pwm1=P100 GPU0(bus01). Fans 40x28mm high-static-pressure; V100 15k rpm max, P100 6k rpm max. Ambient 72-76F. GPU idx (nvidia-smi PCI order): 0=P100(bus01), 1=V100(bus03), 2=V100(bus04). Curve=[tempC,duty%] linear; below first pt holds min, above last holds max.",
+  "_comment": "GPU shroud fan control. Curves mirror the user's proven Windows FanControl setup. CONTROL INPUT = max(core, HBM memory) temp: on the V100 the HBM2 memory runs ~15-20C hotter than the core and throttles at ~85C, so the fan is driven off memory temp (passive cards without a memory-temp sensor use core). Wiring/pwm verified: pwm5=V100 GPU1(bus03), pwm4=V100 GPU2(bus04), pwm1=idx0(bus01). Fans 40x28mm high-static-pressure; V100 15k rpm max, pump 6k rpm max. Ambient 72-76F. GPU idx (nvidia-smi PCI order): 0=idx0(bus01, was P100 -> now GTX Titan X stopgap since 2026-07-27 P100 HBM ECC death; self-cooled, fan.speed logged as gpufan%), 1=V100(bus03), 2=V100(bus04). Curve=[tempC,duty%] linear; below first pt holds min, above last holds max.",
   "interval_sec": 4,
   "expected_gpu_count": 3,
   "gpu_wait_timeout_sec": 90,
@@ -10,7 +10,7 @@
     "1": 175,
     "2": 175
   },
-  "_power_limits_note": "Per-GPU sustained power cap in watts, applied at daemon startup with persistence mode (nvidia-smi -pm 1 -pl W). Chosen from power-cap-sweep.sh 2026-07-01. V100 GPU1(idx1)/GPU2(idx2)=175W: at stock 250W the HBM2 pegs 85C and soft-throttles; 175W holds ~83-84C at ~91% decode throughput (200W still hit 85C). P100(idx0)=200W: never throttles (settles ~70-75C, 15C headroom), so this is a longevity/noise trim at ~0% throughput cost. Board limits: V100 100-250W, P100 125-250W. Failure to apply a cap is non-fatal -- the fan daemon keeps running.",
+  "_power_limits_note": "Per-GPU sustained power cap in watts, applied at daemon startup with persistence mode (nvidia-smi -pm 1 -pl W) AND re-reconciled every power_recheck_sec. Chosen from power-cap-sweep.sh 2026-07-01. V100 GPU1(idx1)/GPU2(idx2)=175W: at stock 250W the HBM2 pegs 85C and soft-throttles; 175W holds ~83-84C at ~91% decode throughput (200W still hit 85C). idx0=200W: GTX Titan X stopgap (board default 250W, range 150-275W). A 250W sustained-load test 2026-07-27 showed the card's own blower keeps up fine (held 83C, fan only ~50%, NO hard throttle), BUT Maxwell GPU Boost 2.0 has an 83C temp target and self-trims boost clocks to hold it, so steady state converges to ~200W / ~1126MHz whether the cap is 200W or 250W -- 250W only buys a ~4s opening burst. So we keep the 200W longevity/noise trim (thermally & perf identical at steady state, slightly cooler bursts). Board limits: V100 100-250W, P100 125-250W, Titan X 150-275W. Failure to apply a cap is non-fatal -- the fan daemon keeps running.",
   "zones": [
     {
       "name": "V100 GPU1 (bus03)",
@@ -53,24 +53,19 @@
       ]
     },
     {
-      "name": "P100 (PUMP_FAN)",
+      "name": "Titan X (idx0, self-cooled)",
+      "_zone_note": "STOPGAP 2026-07-27: the P100 (idx0/bus01) died from an uncorrectable HBM2 double-bit ECC error (Xid 48/64/62/171/154, page-retirement fatal, microcontroller halt -> whole NVML wedged). Replaced by a 12GB GTX Titan X (Maxwell sm_52). Unlike the passive P100, the Titan X cools itself with its OWN built-in fan (readable via nvidia-smi fan.speed, logged as gpufan%) and does NOT use the chassis PUMP_FAN. So this zone is monitor_only: it logs the card's temp + its own fan but drives no chassis PWM. The listed pwm (pwm1, the old P100 pump fan) is handed back to BIOS auto at startup so we stop forcing an unused fan. When a passive P100/V100 returns to idx0, drop monitor_only and restore the curve/min_duty below.",
       "gpus": [
         0
       ],
+      "monitor_only": true,
       "hwmon_name": "nct6792",
       "pwm": "pwm1",
-      "min_duty": 70,
-      "hysteresis_c": 3,
-      "curve": [
-        [
-          38,
-          70
-        ],
-        [
-          70,
-          100
-        ]
-      ]
+      "_restore_p100_curve": {
+        "min_duty": 70,
+        "hysteresis_c": 3,
+        "curve": [[38, 70], [70, 100]]
+      }
     }
   ],
   "_pwm_mapping_note": "PHYSICAL mapping verified via verify-gpu-fan-mapping.sh 2026-07-01 (idle cross-test, one V100 fan MAX / other FLOOR): pwm5 cools GPU1(bus03), pwm4 cools GPU2(bus04). This is SWAPPED vs the naive identify-fan.sh guess. pwm1=P100(6.5k). pwm2=case/CPU, pwm3=3-pin side fan over V100s (non-PWM, BIOS). NOTE: fan RPM correlating with a GPU's temp under the daemon only proves the daemon drives that pwm from that GPU -- NOT which card it physically cools; only the forced-fan cross-test does."

--- a/scripts/gpu-fan-control.py
+++ b/scripts/gpu-fan-control.py
@@ -46,9 +46,16 @@ def gpu_temps():
     than the GPU core and throttles at ~85 C -- so the fan MUST be driven off the
     memory temperature, not the core. We control on eff = max(core, mem). The P100
     reports temperature.memory as N/A, so it falls back to core only.
+
+    We also read fan.speed: the passive datacenter cards (P100/V100) report N/A
+    (they are cooled only by the chassis shroud fans this daemon drives), but a
+    consumer card that self-cools with its own onboard fan (e.g. the GTX Titan X
+    stopgap in idx0) reports its fan duty -- we surface that in the log so its
+    self-managed cooling is visible.
     """
     out = subprocess.check_output(
-        ["nvidia-smi", "--query-gpu=index,temperature.gpu,temperature.memory",
+        ["nvidia-smi",
+         "--query-gpu=index,temperature.gpu,temperature.memory,fan.speed",
          "--format=csv,noheader,nounits"], text=True)
     temps = {}
     for line in out.strip().splitlines():
@@ -60,8 +67,14 @@ def gpu_temps():
                 mem = int(parts[2])
             except ValueError:      # "N/A" / "[Not Supported]"
                 mem = None
+        fan = None
+        if len(parts) > 3:
+            try:
+                fan = int(parts[3])
+            except ValueError:      # passive cards report "[N/A]"
+                fan = None
         eff = max(core, mem) if mem is not None else core
-        temps[idx] = {"core": core, "mem": mem, "eff": eff}
+        temps[idx] = {"core": core, "mem": mem, "eff": eff, "fan": fan}
     return temps
 
 
@@ -181,21 +194,38 @@ class Zone:
     def __init__(self, cfg):
         self.name = cfg["name"]
         self.gpus = cfg["gpus"]
-        self.curve = sorted(cfg["curve"])
         self.hysteresis = cfg.get("hysteresis_c", 3)
         self.min_duty = cfg.get("min_duty", 30)
-        hw = find_hwmon(cfg.get("hwmon_name", "nct6775"))
-        if hw is None:
-            raise RuntimeError(f"hwmon '{cfg.get('hwmon_name')}' not found")
-        self.pwm = os.path.join(hw, cfg["pwm"])
-        self.enable = self.pwm + "_enable"
-        if "REPLACE_ME" in cfg["pwm"] or not os.path.exists(self.pwm):
+        # A monitor-only zone drives NO chassis PWM -- it exists purely to log a
+        # GPU's temp (and its own onboard fan) when the card cools itself (e.g. a
+        # consumer GTX Titan X, whose built-in fan replaces the passive P100's
+        # chassis pump fan). Any pwm listed is only used to hand that header back
+        # to BIOS auto at startup so we stop forcing an unused fan.
+        self.monitor_only = cfg.get("monitor_only", False)
+        self.curve = sorted(cfg.get("curve", []))
+        self.pwm = None
+        self.enable = None
+        pwm_name = cfg.get("pwm")
+        if pwm_name and "REPLACE_ME" not in pwm_name:
+            hw = find_hwmon(cfg.get("hwmon_name", "nct6775"))
+            if hw is None:
+                raise RuntimeError(f"hwmon '{cfg.get('hwmon_name')}' not found")
+            pwm_path = os.path.join(hw, pwm_name)
+            if not os.path.exists(pwm_path):
+                raise RuntimeError(
+                    f"zone '{self.name}': pwm channel '{pwm_name}' not found "
+                    f"({pwm_path}). Run identify-fan.sh and edit the config.")
+            self.pwm = pwm_path
+            self.enable = pwm_path + "_enable"
+        elif not self.monitor_only:
             raise RuntimeError(
-                f"zone '{self.name}': pwm channel '{cfg['pwm']}' not set/found "
-                f"({self.pwm}). Run identify-fan.sh and edit the config.")
+                f"zone '{self.name}': no pwm channel set. Run identify-fan.sh "
+                f"and edit the config (or mark the zone monitor_only).")
         self._last_temp = None
 
     def set_enable(self, mode):
+        if self.enable is None:
+            return
         try:
             open(self.enable, "w").write(str(mode))
         except OSError as e:
@@ -210,20 +240,30 @@ class Zone:
     def update(self, temps):
         # eff = max(core, memory) across this zone's GPUs; memory is the V100
         # throttle limiter and runs much hotter than the core under load.
-        vals = [temps.get(i, {"core": 0, "mem": None, "eff": 0}) for i in self.gpus]
+        vals = [temps.get(i, {"core": 0, "mem": None, "eff": 0, "fan": None}) for i in self.gpus]
         t = max((v["eff"] for v in vals), default=0)
         core = max((v["core"] for v in vals), default=0)
         mem = max((v["mem"] for v in vals if v["mem"] is not None), default=None)
+        gpufan = next((v["fan"] for v in vals if v.get("fan") is not None), None)
+        label = f"{core}C" if mem is None else f"c{core}/m{mem}C"
+        # A self-cooled card (consumer GPU with its own fan) reports its fan duty;
+        # passive P100/V100 report N/A. Surface it so the card's own cooling shows.
+        if gpufan is not None:
+            label += f" gpufan{gpufan}%"
+        if self.monitor_only:
+            # No chassis fan to drive; the card manages its own cooling.
+            return label, None
         # hysteresis: only react if temp moved enough
         if self._last_temp is not None and abs(t - self._last_temp) < self.hysteresis:
             t = self._last_temp
         else:
             self._last_temp = t
         duty = self.write_duty(interp(self.curve, t))
-        label = f"{core}C" if mem is None else f"c{core}/m{mem}C"
         return label, duty
 
     def full_speed(self):
+        if self.monitor_only or self.pwm is None:
+            return
         self.set_enable(1)
         try:
             self.write_duty(100)
@@ -231,6 +271,8 @@ class Zone:
             pass
 
     def restore_auto(self):
+        if self.enable is None:
+            return
         # 5 = nct6775 "smart fan"/BIOS auto; fall back to 2, then full speed.
         for mode in (5, 2):
             try:
@@ -258,7 +300,10 @@ def main():
     reconcile_power_limits(power_limits)
     last_power_check = time.time()
     for z in zones:
-        z.set_enable(1)  # manual PWM
+        if z.monitor_only:
+            z.restore_auto()  # hand any listed header back to BIOS; we only log
+        else:
+            z.set_enable(1)  # manual PWM
     log(f"controlling {len(zones)} zone(s), interval {interval}s, "
         f"power recheck {power_recheck}s")
 
@@ -291,7 +336,10 @@ def main():
             for z in zones:
                 try:
                     label, duty = z.update(temps)
-                    status.append(f"{z.name}:{label}->{duty:.0f}%")
+                    if duty is None:
+                        status.append(f"{z.name}:{label}[monitor]")
+                    else:
+                        status.append(f"{z.name}:{label}->{duty:.0f}%")
                 except Exception as e:
                     log(f"{z.name} update error ({e}) -> 100%")
                     z.full_speed()


### PR DESCRIPTION
## Incident
The Tesla P100 (idx0) died from an **uncorrectable HBM2 double-bit ECC error** (Xid 48/64/62/171/154 — page-retirement fatal → microcontroller halt), which wedged the entire NVML stack (every `nvidia-smi` hung, load spiked, status page dead). Diagnosed as a **silicon HBM failure** — ruled out the driver (ran clean 2 days on the same 580.173.02) and cooling (never throttled, ~70-75 °C). Reset impossible (halted µC). Replaced with a stopgap **12 GB GTX Titan X (Maxwell sm_52)**.

Full write-up in **ADR-0017**.

## Changes
**`config/llama-swap.base.yaml`** — repoint the three idx0 models for the 12 GB card:
- `fast`: 26B MoE (~15.9 GB) → dense Gemma-4-12B (MoE preserved in comments for restore)
- `fast-12b` / `fast-uncensored`: ctx 128k → 32k (128k OOMs on 12 GB)
- **Strip the MTP draft** (`--spec-type draft-mtp`) from all three — it CUDA-faults on Maxwell in `common_speculative_impl_draft_mtp::draft`, only on a real completion (load/health pass first). This was the "activity but no output" bug.

**`scripts/gpu-fan-control.py` + `.config.json`**:
- Read `nvidia-smi fan.speed`; log a self-cooled card's own fan as `gpufan%`
- New `monitor_only` zone type — idx0 (Titan X) self-cools with its own fan and does **not** use the chassis PUMP_FAN, so the daemon only monitors it and hands pwm1 back to BIOS auto
- Power caps unchanged (idx0 200 W; a 250 W load test held 83 °C with no throttle, but Maxwell's 83 °C boost target self-limits to ~200 W either way — noted in config)

**`docs/adr/0017-*.md`** — new ADR (failure mode, diagnosis, remedy) + README index.

## Validation
All 5 models serve through the router: `fast`/`fast-12b`/`fast-uncensored` on the Titan X, `coding`/`chat` on the V100s. Power caps confirmed (V100 175 W, Titan X 200 W).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>