### PR TITLE
Status page: storage metrics + ComfyUI in Services; ADR-0018 GPU upgrade eval

### DIFF
--- a/docs/adr/0018-gpu-upgrade-eval-16-32gb.md
+++ b/docs/adr/0018-gpu-upgrade-eval-16-32gb.md
@@ -1,0 +1,133 @@
+# ADR-0018: GPU upgrade evaluation — 16/24/32 GB cards, arch→CUDA→feature→bandwidth→chassis-fit
+
+- **Status:** Accepted (evaluation record — no purchase committed)
+- **Date:** 2026-07-27
+- **Deciders:** @bradrlaw (+ Copilot CLI)
+
+## Context
+The Tesla P100 died (ADR-0017) and a 12 GB GTX Titan X (Maxwell **sm_52**) is a
+temporary idx0 stopgap. The owner is weighing a permanent replacement / additional
+card and asked, across the 16/24/32 GB tiers: what's newer than the V100s, does a
+new card force **CUDA 13**, and would it unlock newer model formats / attention
+(fp8, INT8/INT4 quant, **NVFP4/FP4**, FlashAttention-3, SageAttention-3)?
+
+Fixed constraints that shape the answer (see also ADR-0002/0003/0009, memories):
+- **One system-wide driver.** R580 (`580.173.02`) already advertises **CUDA 13.0**
+  runtime *and* still supports Maxwell/Pascal/Volta → the driver is **not** the gate.
+- **CUDA *toolkit* is the gate, per-build.** CUDA 13 **dropped sm_52/60/70**, so a
+  CUDA-13-compiled binary **cannot target the Titan X or the V100s**. CUDA 12.9 still
+  builds for sm_52/60/70 **and** supports Ampere (sm_86) / Ada (sm_89). Only
+  **Blackwell (sm_120)** *requires* CUDA 13.
+- **Chassis/thermal ethos:** AZZA Solano full-tower, blower/shroud-cooled cards on
+  dedicated fans, power-capped ~175–200 W for longevity/noise (V100s at 175 W,
+  HBM throttles ~85 °C). Open-air triple-slot 300–575 W cards fight this hard.
+- **PCIe:** all PEG ports cap **x8** (no x16 available; V100s bifurcated x8/x8 off
+  root port 00:03; idx0/bus01 slot trains x4). Single-GPU inference is unaffected.
+- **Bandwidth reference:** the served V100s are **HBM2 ~900 GB/s**. LLM decode is
+  bandwidth-bound, so "newer" ≠ "faster" unless bandwidth ≥ ~900 GB/s.
+- **Ecosystem is CUDA-only** (llama.cpp CUDA build, Nunchaku, SageAttention,
+  ComfyUI fp8 paths). AMD ROCm cards (e.g. W7800 32 GB) break the stack (Nunchaku
+  has no ROCm) → excluded.
+
+### Feature → hardware/toolchain gates (the core matrix)
+| Capability | Min arch | Toolchain | On current V100/Titan? |
+|---|---|---|---|
+| FP16/BF16 tensor cores | Volta sm_70 | CUDA 12.x | V100 yes; Titan (sm_52) no |
+| INT8 tensor GEMM (IMMA, `torch._int_mm`) | **Turing sm_75** | CUDA 12.x | **No** (Volta TC is FP16-only) |
+| INT8/INT4 quant (INT8-Toolkit `convrot`, Nunchaku SVDQuant INT4) | sm_75+ (best sm_86/89) | CUDA 12.x | No |
+| Native **fp8** + **FlashAttention-2** + **SageAttention-2** | **Ada sm_89** | CUDA 12.x | No |
+| **FlashAttention-3** (TMA/WGMMA/native fp8) | **Hopper sm_90** (datacenter) | CUDA 13 | No — not buyable in a consumer card |
+| **NVFP4 / FP4** weights **and** **SageAttention-3** FP4 attention | **Blackwell sm_120** | **CUDA 13 + newest cuDNN** | No |
+
+Key takeaways: (1) "FlashAttention isn't a CUDA feature" — it's separate kernels
+(Dao-AILab lib + cuDNN fused attention) gated by **arch**; the toolkit only lets the
+newest kernels compile/dispatch. (2) **Ada gains nothing from CUDA 13** — its ceiling
+(FA2 + SageAttn-2 + fp8 + INT8/INT4) is fully available on **CUDA 12.9**. (3) The
+entire **FP4 tier — NVFP4 quant *and* SageAttention-3 attention — is one gate:
+Blackwell + CUDA 13.**
+
+## Decision
+**Record the evaluation; do not commit a purchase.** Guidance captured for when the
+owner decides:
+
+1. **Default replacement for the idx0 Titan-X slot = a blower Ampere/Ada card on
+   CUDA 12.9, no toolchain change.** Preferred picks by VRAM:
+   - **16 GB → RTX A4000** (single-slot, 140 W, sm_86; retires the Maxwell card,
+     transforms ComfyUI with INT8/INT4 + FA2; cleanest physical/power fit).
+   - **24 GB → RTX A5000** (2-slot blower, 230 W, sm_86) — more headroom, same fit.
+   - Add **`86`/`89`** to `CMAKE_CUDA_ARCHITECTURES` (currently `52;60;61;70`) and
+     rebuild llama.cpp once; one unified binary still spans all cards.
+2. **Only pursue Blackwell (sm_120) if NVFP4 / FP4-attention is an explicit goal.**
+   Cheapest on-ramp = **RTX 5060 Ti 16 GB (~$429)**. Run ComfyUI on that card from a
+   **separate CUDA-13 PyTorch venv**, `CUDA_VISIBLE_DEVICES`-pinned; the native
+   llama.cpp V100 stack stays on CUDA 12.9. Two toolchains coexist under the one R580
+   driver. This is tolerable *because* ComfyUI is a self-contained per-GPU process —
+   it would be far more painful for the unified llama.cpp binary.
+3. **A 24 GB card is not a V100 upgrade** (less VRAM than the existing 32 GB V100s) —
+   treat 16/24 GB cards as **Titan-X replacement / ComfyUI + `fast`-model** cards.
+   Only **32 GB** matches V100 capacity, and only **GDDR7 Blackwell** 32 GB beats
+   V100 bandwidth (pulling into CUDA 13).
+
+### Reference tables (bandwidth vs V100 ~900 GB/s; prices ≈ 2026, indicative)
+**16 GB** — cheapest tier, best chassis fit, cheapest NVFP4 entry:
+| Card | Arch | BW GB/s | Power | Form | CUDA |
+|---|---|---|---|---|---|
+| **RTX A4000** | Ampere 86 | 448 | 140 W | 1-slot blower | 12.9 |
+| RTX 2000 Ada | Ada 89 | 224 | 70 W | 1-slot | 12.9 |
+| RTX 4060 Ti 16G | Ada 89 | 288 | 165 W | 2-slot | 12.9 |
+| RTX 4070 Ti Super | Ada 89 | 672 | 285 W | 3-slot OA | 12.9 |
+| RTX 4080/Super | Ada 89 | 717–736 | 320 W | 3-slot OA | 12.9 |
+| **RTX 5060 Ti 16G** | Blackwell 120 | 448 | 180 W | 2-slot | **13** |
+| RTX 5070 Ti | Blackwell 120 | 896 ✅ | 300 W | 3-slot OA | **13** |
+| RTX 5080 | Blackwell 120 | 960 ✅ | 360 W | 3-slot OA | **13** |
+
+**24 GB** — Titan-X replacement w/ headroom (still < V100 32 GB):
+| Card | Arch | BW GB/s | Power | Form | CUDA |
+|---|---|---|---|---|---|
+| RTX 3090 | Ampere 86 | 936 ✅ | 350 W | 3-slot OA | 12.9 |
+| RTX 4090 | Ada 89 | 1008 ✅ | 450 W | 3-slot OA | 12.9 |
+| **RTX A5000** | Ampere 86 | 768 | 230 W | 2-slot blower | 12.9 |
+| RTX 4500 Ada | Ada 89 | 672 | 210 W | 2-slot blower | 12.9 |
+| A10 | Ampere 86 | 600 | 150 W | 1-slot passive | 12.9 |
+| L4 | Ada 89 | 300 | 72 W | 1-slot passive | 12.9 |
+| RTX PRO 4000 Blackwell | Blackwell 120 | ~672* | ~140–275*W | 2-slot | **13** |
+
+**32 GB** — only tier matching V100 capacity:
+| Card | Arch | BW GB/s | Power | Form | CUDA |
+|---|---|---|---|---|---|
+| RTX 5000 Ada | Ada 89 | 576 ⚠️ | 250 W | 2-slot blower | 12.9 |
+| RTX PRO 4500 Blackwell | Blackwell 120 | ~900+* | ~200 W | 2-slot blower | **13** |
+| RTX 5090 | Blackwell 120 | 1790 ✅ | 575 W | 3-slot OA | **13** |
+
+\* preliminary / not fully verified. OA = open-air. Note **V100S 32 GB / GV100 are
+still Volta** (not newer); A100 = 40/80 GB; RTX PRO 5000 Blackwell = 48 GB.
+
+## Consequences
+- Positive: any Ampere/Ada pick retires the crippled Maxwell Titan X, unlocks the
+  fp8/INT8/INT4 + FA2/SageAttn-2 ComfyUI stack, and stays on the existing CUDA 12.9
+  unified build (one-line arch add). Clear, cheap, low-risk.
+- Negative / trade-offs: **the recurring tension** — server-friendly blower cards are
+  bandwidth-compromised (all < V100's 900 GB/s); the cards that beat the V100 are hot
+  open-air 300–575 W parts that fight the cooling/power ethos. And the whole FP4 tier
+  costs a second (CUDA-13) toolchain.
+- Follow-ups / things to watch: if Blackwell is chosen, add a CUDA-13 ComfyUI venv
+  (per-GPU pin) and a build note; re-verify PRO 4000/4500 Blackwell specs (marked \*)
+  at purchase time; confirm the idx0 x8 slot trains as expected; update
+  `gpu-fan-control.config.json` (blower card rejoins a PWM curve; drop `monitor_only`)
+  and `power_limits`; rebuild llama.cpp with the added arch and restore MTP draft only
+  on sm_70+ cards (Maxwell MTP crash per ADR-0017).
+
+## Alternatives considered
+- **Go straight to CUDA 13 for the whole box** — rejected; drops sm_52/60/70, orphaning
+  the V100s and Titan X. CUDA 12.9 + R580 already runs a CUDA-13 binary side-by-side
+  when a Blackwell card warrants it (ADR-0002/0003 stand).
+- **RTX 5090 (32 GB, 1.79 TB/s)** — fastest and 2× V100 bandwidth, but 575 W triple-slot
+  open-air; incompatible with the blower/power-cap chassis without a cooling/PSU
+  rebuild. Deferred.
+- **RTX 5000 Ada (32 GB)** — matches V100 *capacity* on CUDA 12.9, but 576 GB/s is
+  **below** the V100 it would pair with → a decode downgrade; value is features, not
+  speed. Only if fp8/features at 32 GB with zero toolchain change is the priority.
+- **AMD Radeon PRO W7800 (32 GB, ROCm)** — rejected; breaks the CUDA-only stack
+  (Nunchaku/SageAttention/llama.cpp CUDA build).
+- **Used RTX 3090/4090 (24 GB, ≥900 GB/s)** — best raw decode-per-dollar, but
+  open-air 350–450 W; only if bandwidth outweighs chassis/power fit.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,7 @@ sessions) don't re-litigate settled choices or lose the reasoning behind them.
 | [0015](0015-llama-swap-serving-modes.md) | llama-swap serving modes (base + overlay) | Accepted |
 | [0016](0016-personal-assistant-gateways.md) | Personal-assistant gateway layer (OpenClaw + Hermes) | Accepted |
 | [0017](0017-p100-hbm-ecc-death-titan-x-stopgap.md) | P100 HBM2 ECC death: diagnosis + Titan X stopgap swap | Accepted |
+| [0018](0018-gpu-upgrade-eval-16-32gb.md) | GPU upgrade eval (16/24/32 GB): arch→CUDA→feature→bandwidth→fit | Accepted |
 
 ## Template
 Copy [`template.md`](template.md) for new records.

--- a/scripts/server-status-service.py
+++ b/scripts/server-status-service.py
@@ -23,7 +23,7 @@ Bind address/port and upstreams are configurable via environment variables:
   STATUS_HOST (default 0.0.0.0)      STATUS_PORT (default 9095)
   LLAMASWAP_URL (default http://127.0.0.1:9090)
   COMFYUI_URLS  (default "open=http://127.0.0.1:8188,secure=http://127.0.0.1:8189")
-  STATUS_DISK_PATHS (default "/", comma-separated filesystems to report)
+  STATUS_DISK_PATHS (default reports Root + bulk + secure; "label=path=kind" items)
   STATUS_CACHE_SECS (default 2)
 
 Optional background workers:
@@ -61,10 +61,39 @@ BENCH_CHART = os.environ.get(
 BENCH_DOC_URL = os.environ.get(
     "BENCH_DOC_URL",
     "https://github.com/bradrlaw/ai-server/blob/dev/docs/benchmarking.md")
-# Comma-separated filesystem paths to report disk usage for (one row each).
-STATUS_DISK_PATHS = [
-    p.strip() for p in os.environ.get("STATUS_DISK_PATHS", "/").split(",") if p.strip()
-]
+# Comma-separated filesystems to report disk usage for (one row each). Each item is
+# "label=path=kind"; label and kind are optional (bare "path" also works). kind is:
+#   plain  — always report statvfs of whatever is at path (default; e.g. Root "/").
+#   mount  — an auto-mounted volume (e.g. the bulk drive): if not currently mounted,
+#            report status "offline" instead of the underlying root fs.
+#   secure — an on-demand encrypted mount (LUKS): if not mounted, report "locked".
+# Detecting the not-mounted case matters so a locked/absent volume doesn't silently
+# show the root filesystem's usage.
+def _parse_disk_specs(raw: str):
+    specs = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        parts = [x.strip() for x in item.split("=")]
+        if len(parts) == 1:
+            label, path, kind = parts[0], parts[0], "plain"
+        elif len(parts) == 2:
+            label, path, kind = parts[0], parts[1], "plain"
+        else:
+            label, path, kind = parts[0], parts[1], (parts[2] or "plain")
+        specs.append((label, path, kind.lower()))
+    return specs
+
+
+STATUS_DISK_PATHS = _parse_disk_specs(
+    os.environ.get(
+        "STATUS_DISK_PATHS",
+        "Root=/,"
+        "Bulk=/srv/ai/storage-bulk=mount,"
+        "Secure=/srv/ai/storage=secure",
+    )
+)
 COMFYUI_URLS = os.environ.get(
     "COMFYUI_URLS",
     "open=http://127.0.0.1:8188,secure=http://127.0.0.1:8189",
@@ -609,19 +638,49 @@ def _mem_info():
     }
 
 
-def _disk_info(paths):
+def _disk_info(specs):
     out = []
-    for p in paths:
+    for label, path, kind in specs:
+        mounted = os.path.ismount(path)
+        # A configured mount/secure volume that isn't currently mounted: report its
+        # status rather than the underlying root fs it would otherwise resolve to.
+        if not mounted and kind in ("mount", "secure"):
+            out.append(
+                {
+                    "path": path,
+                    "label": label,
+                    "status": "locked" if kind == "secure" else "offline",
+                    "mounted": False,
+                    "total_gb": None,
+                    "used_gb": None,
+                    "used_pct": None,
+                }
+            )
+            continue
         try:
-            st = os.statvfs(p)
+            st = os.statvfs(path)
         except Exception:
+            out.append(
+                {
+                    "path": path,
+                    "label": label,
+                    "status": "unavailable",
+                    "mounted": mounted,
+                    "total_gb": None,
+                    "used_gb": None,
+                    "used_pct": None,
+                }
+            )
             continue
         total = st.f_blocks * st.f_frsize
         free = st.f_bavail * st.f_frsize
         used = total - free
         out.append(
             {
-                "path": p,
+                "path": path,
+                "label": label,
+                "status": "ok",
+                "mounted": mounted,
                 "total_gb": round(total / 1e9, 1),
                 "used_gb": round(used / 1e9, 1),
                 "used_pct": round(100.0 * used / total, 1) if total else None,
@@ -1262,8 +1321,18 @@ async function refresh(){  try{
       rows.push(bar('CPU', h.cpu_pct, cpuTxt));
       if(h.mem){ rows.push(bar('RAM', h.mem.used_pct,
         `${(h.mem.used_mb/1024).toFixed(1)} / ${(h.mem.total_mb/1024).toFixed(1)} GB`)); }
-      (h.disk||[]).forEach(dk=>{ rows.push(bar('Disk '+esc(dk.path), dk.used_pct,
-        `${dk.used_gb.toFixed(0)} / ${dk.total_gb.toFixed(0)} GB`)); });
+      (h.disk||[]).forEach(dk=>{
+        const nm='Disk '+esc(dk.label||dk.path);
+        if(dk.used_pct==null){
+          const st=dk.status||'n/a';
+          const cls=(st==='locked')?'busy':'bad';
+          const icon=(st==='locked')?'🔒 ':'';
+          rows.push(bar(nm, null, `<span class="pill ${cls}">${icon}${esc(st)}</span>`));
+        } else {
+          rows.push(bar(nm, dk.used_pct,
+            `${dk.used_gb.toFixed(0)} / ${dk.total_gb.toFixed(0)} GB`));
+        }
+      });
       document.getElementById('host').innerHTML =
         '<table><tr><th>Resource</th><th>Usage</th><th></th></tr>'+rows.join('')+'</table>';
     } else { document.getElementById('host').innerHTML = pill('unavailable'); }

--- a/scripts/server-status-service.py
+++ b/scripts/server-status-service.py
@@ -43,6 +43,7 @@ import subprocess
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 import datetime as dt
 from collections import deque
@@ -481,12 +482,16 @@ def collect_comfyui() -> list:
         label, url = pair.split("=", 1)
         label = label.strip()
         url = url.strip().rstrip("/")
+        try:
+            port = urllib.parse.urlsplit(url).port
+        except Exception:
+            port = None
         code, q = _http_status(f"{url}/queue")
         if code in (401, 403):
-            out.append({"label": label, "state": "locked"})
+            out.append({"label": label, "state": "locked", "port": port})
             continue
         if code is None or q is None:
-            out.append({"label": label, "state": "unreachable"})
+            out.append({"label": label, "state": "unreachable", "port": port})
             continue
         running = len(q.get("queue_running") or [])
         pending = len(q.get("queue_pending") or [])
@@ -496,6 +501,7 @@ def collect_comfyui() -> list:
                 "state": "busy" if (running or pending) else "idle",
                 "running": running,
                 "pending": pending,
+                "port": port,
             }
         )
     return out
@@ -1190,7 +1196,6 @@ _HTML = """<!doctype html>
   <section><h2>GPUs</h2><div id="gpus">…</div></section>
   <section><h2>History <span class="hsub" id="histspan"></span></h2><div id="history">…</div></section>
   <section><h2>Host (CPU / RAM / Disk)</h2><div id="host">…</div></section>
-  <section><h2>ComfyUI</h2><div id="comfyui">…</div></section>
   <section><h2>Services</h2><div id="services">…</div></section>
   <section id="benchsec"><h2>Benchmarks <span class="hsub">· <a id="benchlink" href="__BENCH_DOC_URL__" target="_blank" style="color:#8b95a7">docs/benchmarking.md</a></span></h2>
     <div class="sub" style="margin-bottom:8px">llama-swap <code>--parallel</code> throughput sweep — peak aggregate tok/s per model (higher = more concurrent throughput; raising <code>--parallel</code> divides per-request context).</div>
@@ -1336,23 +1341,29 @@ async function refresh(){  try{
       document.getElementById('host').innerHTML =
         '<table><tr><th>Resource</th><th>Usage</th><th></th></tr>'+rows.join('')+'</table>';
     } else { document.getElementById('host').innerHTML = pill('unavailable'); }
-    // comfyui
-    document.getElementById('comfyui').innerHTML = d.comfyui.length ?
-      d.comfyui.map(c=>`<div style="margin:4px 0">${esc(c.label)}: ${pill(c.state)}` +
-        (c.state==='busy'?` <span class="sub">${c.running} running, ${c.pending} queued</span>`:'') + `</div>`).join('')
-      : pill('none');
-    // services (app-tier health + click-through links built from browser host)
+    // services (app-tier health + click-through links) with ComfyUI folded in
     const svc = d.services || [];
-    document.getElementById('services').innerHTML = svc.length ?
-      '<table><tr><th>Service</th><th>State</th><th>Link</th></tr>' +
-      svc.map(s=>{
-        const p = s.up ? `<span class="pill idle">up</span>` : `<span class="pill bad">down</span>`;
-        const code = s.code!=null ? ` <span class="sub">${s.code}</span>` : '';
-        const link = s.link ? `<a href="${esc(s.link)}" target="_blank" style="color:#4b8ce0">${esc(s.link.replace('https://','').replace('http://',''))}</a>`
-          : s.port!=null ? `<a href="http://${location.hostname}:${s.port}" target="_blank" style="color:#4b8ce0">:${s.port}</a>`
-          : '<span class="sub">–</span>';
-        return `<tr><td>${esc(s.name)}</td><td>${p}${code}</td><td>${link}</td></tr>`;
-      }).join('') + '</table>'
+    const comfy = d.comfyui || [];
+    const linkHtml = (link, port) =>
+      link ? `<a href="${esc(link)}" target="_blank" style="color:#4b8ce0">${esc(link.replace('https://','').replace('http://',''))}</a>`
+      : port!=null ? `<a href="http://${location.hostname}:${port}" target="_blank" style="color:#4b8ce0">:${port}</a>`
+      : '<span class="sub">–</span>';
+    const svcRows = svc.map(s=>{
+      const p = s.up ? `<span class="pill idle">up</span>` : `<span class="pill bad">down</span>`;
+      const code = s.code!=null ? ` <span class="sub">${s.code}</span>` : '';
+      return `<tr><td>${esc(s.name)}</td><td>${p}${code}</td><td>${linkHtml(s.link, s.port)}</td></tr>`;
+    });
+    const comfyRows = comfy.map(c=>{
+      let state;
+      if(c.state==='busy') state = `<span class="pill busy">busy</span> <span class="sub">${c.running} running, ${c.pending} queued</span>`;
+      else if(c.state==='idle') state = `<span class="pill idle">idle</span>`;
+      else if(c.state==='locked') state = `<span class="pill busy">🔒 locked</span>`;
+      else state = `<span class="pill bad">down</span>`;
+      return `<tr><td>ComfyUI <span class="sub">${esc(c.label)}</span></td><td>${state}</td><td>${linkHtml(null, c.port)}</td></tr>`;
+    });
+    const allRows = svcRows.concat(comfyRows);
+    document.getElementById('services').innerHTML = allRows.length ?
+      '<table><tr><th>Service</th><th>State</th><th>Link</th></tr>' + allRows.join('') + '</table>'
       : pill('none');
   }catch(e){ document.getElementById('sub').textContent = 'status service error: ' + e; }
 }

--- a/scripts/server-status.env.example
+++ b/scripts/server-status.env.example
@@ -24,9 +24,13 @@ OWUI_API_KEY=
 # FAST_KEEPER_INTERVAL=60
 
 # --- Host stats ---------------------------------------------------------------
-# Comma-separated filesystems to report disk usage for (default "/"). Add mounts
-# if models/data live on a separate disk, e.g. STATUS_DISK_PATHS=/,/mnt/data
-# STATUS_DISK_PATHS=/
+# Filesystems to report disk usage for (one row each). Each item is
+# "label=path=kind" (label and kind optional; bare "path" also works). kind:
+#   plain  — always statvfs whatever is at path (default; e.g. Root "/").
+#   mount  — auto-mounted volume; if not mounted, shown as "offline".
+#   secure — on-demand LUKS mount; if not mounted, shown as "locked".
+# Default reports Root, the bulk drive, and the encrypted secure volume:
+# STATUS_DISK_PATHS=Root=/,Bulk=/srv/ai/storage-bulk=mount,Secure=/srv/ai/storage=secure
 
 # --- History (dashboard sparklines) -------------------------------------------
 # In-memory time series (per-GPU util/power/temp/VRAM + host CPU/RAM), served at


### PR DESCRIPTION
Independent follow-ups from the Titan-X stopgap session (isolated from the evals PR #26).

### Status page (`scripts/server-status-service.py`, `server-status.env.example`)
- **Storage metrics**: Host panel now reports **Root**, **Bulk** (`/srv/ai/storage-bulk`), and **Secure** (`/srv/ai/storage`). Disk specs gain a `label=path=kind` format; `kind ∈ {plain, mount, secure}`. Uses `os.path.ismount()` so a not-mounted volume reports **`offline`** (mount) or **`🔒 locked`** (secure) instead of silently showing the root fs. Renders null-usage rows safely.
- **ComfyUI folded into Services**: removed the standalone ComfyUI section; the open/secure instances are now rows in the Services table (idle/busy with queue counts, 🔒 locked, or down) with client-side `:port` links. `comfyui` data key unchanged, so summary/banner logic still works.

### Docs
- **ADR-0018**: GPU upgrade evaluation across the 16/24/32 GB tiers — arch→CUDA→feature→bandwidth→chassis-fit. Records the driver≠toolkit≠arch gate logic, the FP4=Blackwell+CUDA-13 rule, reference tables, and picks by chassis fit. Evaluation record only (no purchase committed).

Verified live: `_disk_info` reports Root/Bulk/Secure correctly and the locked/offline branches return null usage; `collect_comfyui` emits ports + states. Requires `sudo systemctl restart server-status` to display.