### PR TITLE
storage-crypt: start comfyui-secure on unlock (fixes dead unit after reboot)

### DIFF
--- a/docs/adr/0013-dual-comfyui-instances.md
+++ b/docs/adr/0013-dual-comfyui-instances.md
@@ -79,6 +79,15 @@ its own V100 via `CUDA_VISIBLE_DEVICES` (+ `CUDA_DEVICE_ORDER=PCI_BUS_ID`):
 * ComfyUI-Login is "basic protection" (its own words) — a shared password, not
   per-user isolation. If true per-user asset separation is later needed, revisit
   ComfyUI-Usgromana or one-instance-per-user.
+* **`comfyui-secure` will not come up on its own after a reboot.** Its drop-in
+  `RequiresMountsFor=/srv/ai/storage` means that at boot — while the encrypted
+  volume is still locked (manual passphrase, ADR: `storage-crypt.sh`) — its start
+  job fails on the missing mount, and systemd does **not** auto-retry once the
+  volume is later unlocked. `scripts/storage-crypt.sh unlock` therefore starts
+  `comfyui-secure` as its final step (best-effort, same as its filebrowser
+  recreate), so unlocking the volume also brings the secure instance up. The
+  dashboard's "▶ Start ComfyUI" button is the manual equivalent. `comfyui-open`
+  has no encrypted dependency and comes up at boot normally.
 
 ## Files
 

--- a/scripts/storage-crypt.sh
+++ b/scripts/storage-crypt.sh
@@ -105,6 +105,23 @@ cmd_unlock() {
     fi
   fi
 
+  # Start the secure ComfyUI instance now that the encrypted volume is present.
+  # comfyui-secure.service has RequiresMountsFor=/srv/ai/storage, so at boot (when
+  # the volume is still locked) its start job fails on the missing mount and systemd
+  # does NOT auto-retry — it stays dead even after a later unlock. Starting it here
+  # closes that gap. Best-effort: never fail the unlock over this (comfyui-open has
+  # no encrypted dependency and comes up at boot on its own).
+  if command -v systemctl >/dev/null 2>&1 \
+     && systemctl list-unit-files comfyui-secure.service >/dev/null 2>&1; then
+    if systemctl is-active --quiet comfyui-secure.service; then
+      echo ">> comfyui-secure already running"
+    else
+      echo ">> starting comfyui-secure (encrypted volume now available)"
+      systemctl start comfyui-secure.service \
+        || echo "   warning: comfyui-secure start failed (start it manually)" >&2
+    fi
+  fi
+
   echo "unlocked."
   cmd_status
 }


### PR DESCRIPTION
`comfyui-secure.service` has `RequiresMountsFor=/srv/ai/storage`. At boot the encrypted LUKS volume is still locked, so its start job fails on the missing mount and systemd does **not** auto-retry once the volume is later unlocked — the unit stays dead until manually started.

Fix: `storage-crypt.sh unlock` now starts `comfyui-secure` as its final best-effort step (mirroring the existing filebrowser-recreate hook), so unlocking the encrypted volume also brings the secure ComfyUI instance up. Documented in ADR-0013.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>