### PR TITLE
UPS graceful shutdown via NUT (CyberPower CP1500)

### DIFF
--- a/docs/adr/0019-ups-graceful-shutdown-nut.md
+++ b/docs/adr/0019-ups-graceful-shutdown-nut.md
@@ -1,0 +1,58 @@
+# ADR-0019: UPS monitoring & graceful shutdown (CyberPower CP1500 via NUT)
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Deciders:** @bradrlaw (+ Copilot CLI)
+
+## Context
+A CyberPower **CP1500AVRLCD** UPS (1500 VA / ~900 W, USB HID Power Device,
+VID:PID `0764:0601`, enumerates as `CPS CP1500AVRLCD3` on hidraw) was connected
+to the headless AI server over USB so the machine can power down cleanly during
+an extended outage instead of losing power mid-inference or mid-write to the
+encrypted volume.
+
+Constraints:
+- Headless box; no vendor GUI. The kernel already exposes the UPS as a standard
+  HID Power Device, so NUT's native `usbhid-ups` driver works without
+  CyberPower's proprietary PowerPanel/`pwrstatd` daemon.
+- The agent cannot `sudo`; privileged install/config is delivered as a script
+  the owner runs (`scripts/ups-setup.sh`).
+- Under GPU load the CP1500's runtime is short, and a clean shutdown (stop
+  Docker app tier, unload GPUs, flush the LUKS volume) takes time — so the
+  shutdown trigger matters.
+
+## Decision
+Use **NUT (Network UPS Tools)** in **standalone** mode with the `usbhid-ups`
+driver, configured by `scripts/ups-setup.sh`. Trigger a graceful
+`shutdown -h` on the UPS **LOW-BATTERY** signal (`OB LB`): ride through short
+blips on battery, and power off only when the battery is nearly empty
+(maximises uptime). `upsd` listens on loopback only (`127.0.0.1:3493`).
+
+## Consequences
+- Positive: brief outages are absorbed silently; extended outages end in a
+  clean, unattended shutdown. Native driver, no vendor daemon, no cloud.
+- Positive: config is reproducible and version-controlled via the script;
+  `/etc/nut/*.conf` back up once (`*.orig-preNUTsetup`) and the generated
+  monitor password is preserved across re-runs.
+- Negative / trade-offs: LOW-BATTERY trigger leaves little reserve — if a clean
+  shutdown ever exceeds remaining runtime the box could still drop hard. Watch
+  the first real/drill event and, if too tight, switch to a timed or
+  charge-threshold trigger (via `upssched`).
+- Follow-ups / things to watch:
+  - Run `sudo /srv/ai/scripts/ups-setup.sh`, then verify with `upsc cyberpower`.
+  - Drill once with `upsmon -c fsd` (forces a shutdown — schedule it).
+  - Consider surfacing `ups.status` / `battery.charge` / `battery.runtime` on
+    the server-status dashboard.
+  - Unrelated but noted the same boot: a flaky `usb 3-11` device on the Intel
+    xHCI (`00:14.0`) fails enumeration and adds ~70 s to boot (recurring, not
+    the UPS). Track down / unplug the offending internal USB device/header.
+
+## Alternatives considered
+- **CyberPower PowerPanel (`pwrstatd`)** — vendor .deb, proprietary, less
+  transparent, and unnecessary since NUT's `usbhid-ups` already speaks to this
+  UPS. Rejected.
+- **`apcupsd`** — APC-oriented; CyberPower support is second-class vs NUT's HID
+  driver. Rejected.
+- **Timed / charge-threshold shutdown** — predictable and leaves reserve, but
+  cuts uptime on every outage. Kept as the documented fallback if the
+  low-battery margin proves too tight.

--- a/scripts/ups-setup.sh
+++ b/scripts/ups-setup.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# ups-setup.sh — configure NUT (Network UPS Tools) for the CyberPower CP1500AVRLCD
+#                so the AI server shuts down gracefully on an extended outage.
+#
+# Hardware:  CyberPower CP1500AVRLCD (USB HID Power Device, VID:PID 0764:0601),
+#            enumerated by the kernel as hidraw "CPS CP1500AVRLCD3".
+# Driver:    NUT usbhid-ups (native, no vendor daemon needed).
+# Mode:      standalone (single machine monitors its own UPS over local USB).
+# Trigger:   graceful `shutdown -h` on the UPS LOW-BATTERY signal (OB LB) —
+#            rides through short blips, powers off only when the battery is
+#            nearly empty, maximising uptime.
+#
+# The agent cannot sudo, so this is handed to the owner to run:
+#     sudo /srv/ai/scripts/ups-setup.sh
+#
+# Idempotent: re-running preserves the generated monitor password and only
+# rewrites config if needed. Existing /etc/nut/*.conf are backed up once.
+#
+set -euo pipefail
+
+UPS_NAME="cyberpower"
+UPS_DESC="CyberPower CP1500AVRLCD"
+VENDORID="0764"
+PRODUCTID="0601"
+NUTDIR="/etc/nut"
+LISTEN_ADDR="127.0.0.1"
+LISTEN_PORT="3493"
+
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root:  sudo $0" >&2
+    exit 1
+fi
+
+echo "==> 1/6  Installing NUT (nut-server + nut-client)…"
+if ! dpkg -l nut-server 2>/dev/null | grep -q '^ii'; then
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+    apt-get install -y nut nut-server nut-client
+else
+    echo "    NUT already installed — skipping apt."
+fi
+
+# NUT's package creates the 'nut' user/group and $NUTDIR.
+NUT_GROUP="$(getent group nut >/dev/null && echo nut || echo root)"
+mkdir -p "$NUTDIR"
+
+backup_once() {
+    local f="$1"
+    if [[ -f "$f" && ! -f "$f.orig-preNUTsetup" ]]; then
+        cp -a "$f" "$f.orig-preNUTsetup"
+        echo "    backed up $(basename "$f") -> $(basename "$f").orig-preNUTsetup"
+    fi
+}
+
+echo "==> 2/6  Reusing or generating the upsmon password…"
+# Preserve the password across re-runs so upsd.users and upsmon.conf stay in sync.
+MON_PASS=""
+if [[ -f "$NUTDIR/upsd.users" ]]; then
+    MON_PASS="$(awk '/^\[upsmon\]/{f=1} f&&/password/{print $NF; exit}' "$NUTDIR/upsd.users" || true)"
+fi
+if [[ -z "$MON_PASS" ]]; then
+    MON_PASS="$(head -c 18 /dev/urandom | base64 | tr -dc 'A-Za-z0-9')"
+    echo "    generated a new random monitor password."
+else
+    echo "    reusing existing monitor password."
+fi
+
+echo "==> 3/6  Writing $NUTDIR/nut.conf (MODE=standalone)…"
+backup_once "$NUTDIR/nut.conf"
+cat > "$NUTDIR/nut.conf" <<EOF
+# Managed by scripts/ups-setup.sh
+MODE=standalone
+EOF
+
+echo "==> 4/6  Writing ups.conf / upsd.conf / upsd.users…"
+backup_once "$NUTDIR/ups.conf"
+cat > "$NUTDIR/ups.conf" <<EOF
+# Managed by scripts/ups-setup.sh
+# Global driver defaults
+maxretry = 3
+
+[$UPS_NAME]
+    driver = usbhid-ups
+    port = auto
+    vendorid = $VENDORID
+    productid = $PRODUCTID
+    desc = "$UPS_DESC"
+EOF
+
+backup_once "$NUTDIR/upsd.conf"
+cat > "$NUTDIR/upsd.conf" <<EOF
+# Managed by scripts/ups-setup.sh
+# Bind the data server to loopback only (single-machine standalone).
+LISTEN $LISTEN_ADDR $LISTEN_PORT
+EOF
+
+backup_once "$NUTDIR/upsd.users"
+cat > "$NUTDIR/upsd.users" <<EOF
+# Managed by scripts/ups-setup.sh
+[upsmon]
+    password = $MON_PASS
+    upsmon primary
+EOF
+
+echo "==> 5/6  Writing upsmon.conf (shut down on LOW BATTERY)…"
+backup_once "$NUTDIR/upsmon.conf"
+cat > "$NUTDIR/upsmon.conf" <<EOF
+# Managed by scripts/ups-setup.sh
+#
+# Monitor the local UPS. Power value 1 = this UPS feeds 1 power supply that we
+# require to stay up (MINSUPPLIES 1). upsmon runs as 'primary' since it is
+# directly attached to the UPS over USB.
+MONITOR $UPS_NAME@localhost 1 upsmon $MON_PASS primary
+
+MINSUPPLIES 1
+
+# On a fatal condition (UPS on battery AND low battery, i.e. "OB LB"),
+# upsmon runs this to bring the box down cleanly. Give a short grace so
+# systemd can stop containers, unload GPUs and flush disks.
+SHUTDOWNCMD "/sbin/shutdown -h +0 'UPS low battery — graceful shutdown'"
+
+POLLFREQ 5
+POLLFREQALERT 5
+HOSTSYNC 15
+DEADTIME 15
+POWERDOWNFLAG /etc/killpower
+FINALDELAY 5
+
+# Log/notify on state changes (syslog only; no wall spam on a headless box).
+NOTIFYFLAG ONLINE   SYSLOG
+NOTIFYFLAG ONBATT   SYSLOG+WALL
+NOTIFYFLAG LOWBATT  SYSLOG+WALL
+NOTIFYFLAG FSD      SYSLOG+WALL
+NOTIFYFLAG SHUTDOWN SYSLOG
+NOTIFYFLAG COMMBAD  SYSLOG
+NOTIFYFLAG COMMOK   SYSLOG
+EOF
+
+echo "==> 5b   Locking down permissions (files hold a password)…"
+chown root:"$NUT_GROUP" "$NUTDIR"/nut.conf "$NUTDIR"/ups.conf "$NUTDIR"/upsd.conf \
+    "$NUTDIR"/upsd.users "$NUTDIR"/upsmon.conf
+chmod 640 "$NUTDIR"/nut.conf "$NUTDIR"/ups.conf "$NUTDIR"/upsd.conf \
+    "$NUTDIR"/upsd.users "$NUTDIR"/upsmon.conf
+
+echo "==> 6/6  Enabling + (re)starting NUT services…"
+# nut-driver-enumerator turns ups.conf sections into nut-driver@ instances.
+systemctl daemon-reload
+systemctl enable nut-driver-enumerator.service nut-server.service nut-monitor.service >/dev/null 2>&1 || true
+systemctl restart nut-driver-enumerator.service || true
+systemctl restart nut-server.service
+systemctl restart nut-monitor.service
+
+sleep 3
+echo
+echo "=========================================================================="
+echo " UPS status (upsc $UPS_NAME):"
+echo "=========================================================================="
+if upsc "$UPS_NAME" 2>/dev/null; then
+    echo
+    echo "SUCCESS — NUT is talking to the UPS."
+    echo "Key fields to sanity-check:"
+    upsc "$UPS_NAME" 2>/dev/null | grep -E \
+      'ups.status|battery.charge|battery.runtime|ups.load|input.voltage' || true
+    echo
+    echo "Test (do NOT do this casually — it simulates a power event):"
+    echo "    upsmon -c fsd        # force a shutdown drill"
+    echo "    upsc $UPS_NAME ups.status   # OL = online, OB = on battery, LB = low"
+else
+    echo "WARNING — could not query the UPS yet. Check:"
+    echo "    systemctl status nut-server nut-monitor 'nut-driver@*'"
+    echo "    journalctl -u nut-server -u 'nut-driver@*' -b --no-pager | tail -40"
+    echo "    lsusb | grep -i cyber"
+fi
+echo "=========================================================================="

--- a/scripts/ups-setup.sh
+++ b/scripts/ups-setup.sh
@@ -118,7 +118,7 @@ MINSUPPLIES 1
 # On a fatal condition (UPS on battery AND low battery, i.e. "OB LB"),
 # upsmon runs this to bring the box down cleanly. Give a short grace so
 # systemd can stop containers, unload GPUs and flush disks.
-SHUTDOWNCMD "/sbin/shutdown -h +0 'UPS low battery — graceful shutdown'"
+SHUTDOWNCMD "/sbin/shutdown -h +0 'UPS low battery - graceful shutdown'"
 
 POLLFREQ 5
 POLLFREQALERT 5

--- a/scripts/ups-setup.sh
+++ b/scripts/ups-setup.sh
@@ -143,11 +143,30 @@ chown root:"$NUT_GROUP" "$NUTDIR"/nut.conf "$NUTDIR"/ups.conf "$NUTDIR"/upsd.con
 chmod 640 "$NUTDIR"/nut.conf "$NUTDIR"/ups.conf "$NUTDIR"/upsd.conf \
     "$NUTDIR"/upsd.users "$NUTDIR"/upsmon.conf
 
+echo "==> 5c   Applying NUT udev rules to the (already-plugged) UPS…"
+# NUT ships /usr/lib/udev/rules.d/62-nut-usbups.rules which chgrps the USB node
+# to group 'nut'. Those rules only fire on a plug event, so if the UPS was
+# already connected before NUT installed, the existing /dev/bus/usb node stays
+# root:root and the driver fails with "insufficient permissions on everything".
+# Reload + re-trigger for this vendor to fix it without a replug/reboot.
+udevadm control --reload-rules || true
+udevadm trigger --action=add --subsystem-match=usb \
+    --attr-match=idVendor="$VENDORID" || true
+sleep 1
+UPSNODE="$(lsusb | awk -v v="$VENDORID" -v p="$PRODUCTID" \
+    'tolower($6)==(v":"p){printf "/dev/bus/usb/%s/%s",$2,substr($4,1,3)}')"
+if [[ -n "${UPSNODE:-}" ]]; then
+    echo "    UPS USB node: $UPSNODE ($(stat -c '%U:%G %a' "$UPSNODE" 2>/dev/null))"
+fi
+
 echo "==> 6/6  Enabling + (re)starting NUT services…"
 # nut-driver-enumerator turns ups.conf sections into nut-driver@ instances.
 systemctl daemon-reload
 systemctl enable nut-driver-enumerator.service nut-server.service nut-monitor.service >/dev/null 2>&1 || true
 systemctl restart nut-driver-enumerator.service || true
+# Restart the per-UPS driver instance so it re-opens the (now group-nut) node.
+systemctl reset-failed "nut-driver@$UPS_NAME.service" 2>/dev/null || true
+systemctl restart "nut-driver@$UPS_NAME.service" || true
 systemctl restart nut-server.service
 systemctl restart nut-monitor.service
 


### PR DESCRIPTION
Configure NUT (`usbhid-ups`, standalone) so the AI server powers down cleanly on the UPS **low-battery** signal.

## What
- `scripts/ups-setup.sh` — idempotent, sudo-run installer (agent can't sudo). Installs NUT, writes `/etc/nut/*` (loopback-only `upsd`, `upsmon primary`, `SHUTDOWNCMD` on `OB LB`), preserves the generated monitor password across re-runs, applies NUT's udev rules to an already-plugged UPS, restarts + verifies with `upsc`.
- `docs/adr/0019-ups-graceful-shutdown-nut.md` — decision record.

## Verified live (2026-08-03)
NUT connected to a CyberPower CP1500AVRLCD (`0764:0601`): `ups.status: OL`, battery 100%, runtime ~2500s @ 21% load, upsmon armed as primary, all services enabled at boot.

## Notes
- Trigger is low-battery (`OB LB`) → `shutdown -h`, leaving the ~300s/10% reserve.
- Fixes included: udev perms for an already-plugged UPS (`insufficient permissions`), and ASCII hyphen in `SHUTDOWNCMD` (upsmon parser rejects the em-dash).

_Note: the original CP1500 unit turned out to have a weak battery (couldn't sustain PSU inrush on battery) and is being replaced; the config is model-portable._

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>