### PR TITLE
Upgrade Open WebUI 0.10.2 -> 0.11.0

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
   # LiteLLM gateway (host :4000, reached via host.docker.internal). Web search
   # via the SearXNG service; MCP tools via the mcpo service.
   open-webui:
-    image: ghcr.io/open-webui/open-webui:v0.10.2
+    image: ghcr.io/open-webui/open-webui:v0.11.0
     container_name: open-webui
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
Bumps `docker/docker-compose.yml` OWUI pin to **v0.11.0**.

## Why
0.11.0 fixes several issues that directly affect this deployment:
- **Assistant replies stored without their text** (empty content/output) — the empty-message symptom recently debugged. ([#26799](https://github.com/open-webui/open-webui/pull/26799))
- **Empty/late reasoning** no longer opens a blank thinking block; late reasoning renders in place. ([#26687](https://github.com/open-webui/open-webui/pull/26687)) — relevant to the reasoning-heavy `coding` model.
- **System prompt lost during tool calls** now persists across tool rounds. ([#26857](https://github.com/open-webui/open-webui/pull/26857))
- **Context size after tool calls** now understands llama.cpp token counts. 
- Streaming perf: leaner filter handling per chunk, cheaper reasoning/code tag detection, steadier long responses, and hostname lookups moved off the shared thread pool (helps MCP tools via host.docker.internal).
- Security / access-control release.

## Upgrade record
- Data volume `open-webui-data` (1.1G) backed up to `storage-bulk/backups/owui/owui-data-20260806-032115.tgz` (clean-shutdown backup).
- 7 alembic schema migrations applied on first boot, no errors.
- Verified `coding` responds end-to-end after upgrade (46K stream, ~44 t/s).

## Note
Major version = full UI redesign; new features (sub-agents, timers, notifications, chat variables) are opt-in.