### PR TITLE
models: move non-MTP swap files to bulk cold tier

### DIFF
--- a/config/modes/agentic.yaml
+++ b/config/modes/agentic.yaml
@@ -34,7 +34,7 @@ overrides:
     concurrencyLimit: 8
     ctx_size: 204800    # non-MTP file gets its full 200k back (204800 / 2 = ~100k/slot)
     spec: none          # MTP is a single-stream latency win; useless for a P=2 throughput pool
-    model: ${models_dir}/qwen3.6-27b/Qwen3.6-27B-Q6_K.gguf  # non-MTP file (no unused head, fits 200k @ P=2)
+    model: ${models_dir}/cold/qwen3.6-27b/Qwen3.6-27B-Q6_K.gguf  # non-MTP file (no unused head, fits 200k @ P=2); on bulk cold tier (loaded on demand)
   gemma-26b:
     parallel: 8
     concurrencyLimit: 16

--- a/config/modes/heavy-coding.yaml
+++ b/config/modes/heavy-coding.yaml
@@ -34,7 +34,7 @@ overrides:
     concurrencyLimit: 12
     ctx_size: 131072
     spec: none    # MTP off for the batched sub-agent pool (helps single-stream, not P=4)
-    model: ${models_dir}/qwen3.6-35b-a3b/Qwen3.6-35B-A3B-UD-Q6_K.gguf  # non-MTP file (no unused head)
+    model: ${models_dir}/cold/qwen3.6-35b-a3b/Qwen3.6-35B-A3B-UD-Q6_K.gguf  # non-MTP file (no unused head); on bulk cold tier (loaded on demand)
   fast:
     parallel: 2
     ctx_size: 24576

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -249,11 +249,15 @@ less fragile and engines independently upgradable.
    `/srv/ai/storage-bulk/models` — hot/served model dirs stay directly under
    `/srv/ai/models/`; rarely-used, base-weight, or superseded-quant dirs (e.g. the plain
    `qwen3.6-27b/` BF16 + `Q4_K_M`/`UD-Q6_K_XL`/`UD-Q8_K_XL` quants, `pxq-fusion4/`,
-   `qwen3.5-9b/`) live under `/srv/ai/models/cold/` on the 1TB. **Gotcha:** check the mode
-   overlays (`config/modes/*.yaml`), not just `llama-swap.base.yaml`, before cold-moving a
-   file — the `agentic` overlay pins `coding` to the non-MTP `qwen3.6-27b/Qwen3.6-27B-Q6_K.gguf`,
-   so that one file is kept hot (only the base/superseded quants above go cold). Nothing in
-   `llama-swap.base.yaml` references `cold/`.
+   `qwen3.5-9b/`) live under `/srv/ai/models/cold/` on the 1TB. The non-MTP swap files used
+   only by the parallel-pool modes are also cold (loaded on demand): `agentic` pins `coding`
+   to `cold/qwen3.6-27b/Qwen3.6-27B-Q6_K.gguf` and `heavy-coding` pins `chat` to
+   `cold/qwen3.6-35b-a3b/Qwen3.6-35B-A3B-UD-Q6_K.gguf` — first switch into those modes pays a
+   one-time ~21–28 GB HDD load (~150 MB/s). **Gotcha:** check the mode overlays
+   (`config/modes/*.yaml`), not just `llama-swap.base.yaml`, before moving a file — a slot's
+   file may differ per mode. Only the daily/base served slots (`coding`+`chat`+`fast` MTP
+   files, uncensored-heretic, etc.) stay on the hot NVMe tier; `llama-swap.base.yaml` itself
+   references no `cold/` paths.
 
 ---
 

--- a/scripts/pxq-dual-debug.py
+++ b/scripts/pxq-dual-debug.py
@@ -28,7 +28,7 @@ FORK2_LD = ":".join([f"{FORK2}/bin", f"{FORK2}/src", f"{FORK2}/ggml/src",
                      f"{FORK2}/examples/mtmd", "/usr/local/cuda/lib64", NCCL])
 FORK2_BIN = f"{FORK2}/bin/llama-server"
 PXQ4 = f"{MODELS}/pxq/Qwen3.6-35B-A3B-PXQ4.gguf"
-Q6K = f"{MODELS}/qwen3.6-35b-a3b/Qwen3.6-35B-A3B-UD-Q6_K.gguf"
+Q6K = f"{MODELS}/cold/qwen3.6-35b-a3b/Qwen3.6-35B-A3B-UD-Q6_K.gguf"
 PORT = 8971
 GPUS = "1,2"           # both V100s, PCI_BUS_ID order
 LOGDIR = "/tmp/pxq-dual-debug"

--- a/scripts/pxq-ppl-run.sh
+++ b/scripts/pxq-ppl-run.sh
@@ -19,7 +19,7 @@ CHUNKS="${1:-100}"; shift || true
 
 declare -A M=(
   [q8]="models/pxq/Qwen3.6-35B-A3B-Q8_0.gguf|Q8_0|reference (near-lossless)"
-  [q6k]="models/qwen3.6-35b-a3b/Qwen3.6-35B-A3B-UD-Q6_K.gguf|Q6_K|standard ~6.5bpw"
+  [q6k]="models/cold/qwen3.6-35b-a3b/Qwen3.6-35B-A3B-UD-Q6_K.gguf|Q6_K|standard ~6.5bpw"
   [pxq6]="models/pxq/Qwen3.6-35B-A3B-PXQ6.gguf|PXQ6|fork ~5.3bpw"
   [q4km]="models/pxq/Qwen3.6-35B-A3B-Q4_K_M.gguf|Q4_K_M|standard ~4.8bpw"
   [pxq4]="models/pxq/Qwen3.6-35B-A3B-PXQ4.gguf|PXQ4|fork ~4.5bpw"


### PR DESCRIPTION
## Problem
The non-MTP GGUFs are only used by the parallel-pool serving modes — `agentic` pins `coding` to the non-MTP 27B and `heavy-coding` pins `chat` to the non-MTP 35B-A3B — where MTP is stripped anyway (`spec: none`). Keeping those ~49 GB on the hot NVMe wastes space we're short on (root was 93% full).

## Change
Move both non-MTP swap files to the 1TB bulk **cold** tier (`models/cold/` → `storage-bulk/models/`) and load them on demand when those modes are activated.

- `config/modes/agentic.yaml`: `coding` → `cold/qwen3.6-27b/Qwen3.6-27B-Q6_K.gguf`
- `config/modes/heavy-coding.yaml`: `chat` → `cold/qwen3.6-35b-a3b/Qwen3.6-35B-A3B-UD-Q6_K.gguf`
- `scripts/pxq-ppl-run.sh`, `scripts/pxq-dual-debug.py`: repoint the Q6_K reference to `cold/`
- `docs/server-setup.md`: update the cold-tier note (non-MTP swap files now cold)

Frees ~49 GB on root NVMe (93% → 89%). **`daily` mode is unaffected** (it uses the MTP files, which stay hot).

## Trade-off
First switch into `agentic`/`heavy-coding` pays a one-time ~21–28 GB HDD read (~150 MB/s ≈ 2–3 min) to load that slot.

## Tests
- Both overlays parse (`yaml.safe_load`).
- `render()` emits the correct `--model ${models_dir}/cold/…` lines for both modes.
- Files verified present and resolvable via the `cold` symlink.
- No live model-load test run (deferred per owner).