### PR TITLE
README attribution for optional add-on tools + fix SwarmUI license

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,18 @@ separately by their respective creators and are not redistributed here.)
 | SearXNG | https://github.com/searxng/searxng | Self-hosted metasearch engine used for web-search tooling. |
 | Filebrowser | https://github.com/filebrowser/filebrowser | Web file manager for browsing/downloading generated assets and models. |
 
+### Optional add-on tools (alternative image-gen UIs + training)
+
+Optional, installed alongside — not replacing — ComfyUI. Install + full attribution in
+[docs/optional-tools.md](docs/optional-tools.md).
+
+| Project | Link | License | How it's used |
+|---------|------|---------|---------------|
+| ai-toolkit | https://github.com/ostris/ai-toolkit | MIT | LoRA / fine-tune **training** UI (Ostris, LLC), on `:8675`. |
+| Fooocus | https://github.com/lllyasviel/Fooocus | GPL-3.0 | Simple, opinionated image-gen UI (lllyasviel / Lvmin Zhang), on `:7865`. |
+| SwarmUI | https://github.com/mcmonkeyprojects/SwarmUI | MIT | Multi-user, ComfyUI-backed image-gen front-end (Alex "mcmonkey" Goodwin), on `:7801`. |
+| InvokeAI | https://github.com/invoke-ai/InvokeAI | Apache-2.0 | Unified-canvas "pro" image-gen studio (Invoke, Inc.), on `:9091`. |
+
 ### ComfyUI custom nodes
 
 | Project | Link | How it's used |

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -215,7 +215,7 @@ web server that drives a Python **ComfyUI backend** under the hood. It gives a
 friendly tabbed "Generate" UI (SDXL/Flux/etc.) on top of Comfy's power, a
 raw-workflow Comfy tab for power users, and — the reason we picked it for the
 family — **real multi-user accounts with per-user permissions and separate image
-history**. Licensed **GPL-3.0**.
+history**. Licensed **MIT**.
 
 **Architecture note.** Unlike the other tools this is *not* a Python app in its
 own venv — it's a .NET server that spawns a self-managed ComfyUI child. So the
@@ -350,7 +350,7 @@ same physical card in torch (idx0=Titan X, idx1/2=V100). sm_70 has no
 fp8/FlashAttention-2, so the backend uses PyTorch cross-attention (sdpa) — the
 correct path for Volta.
 
-**Attribution.** SwarmUI © Alex "mcmonkey" Goodwin and contributors, GPL-3.0 —
+**Attribution.** SwarmUI © Alex "mcmonkey" Goodwin and contributors, MIT License —
 <https://github.com/mcmonkeyprojects/SwarmUI>. Contributions to SwarmUI itself are
 governed by its own `AGENTS.md`; we only *deploy* it and keep its tree pristine,
 putting all customization in this repo's scripts.


### PR DESCRIPTION
Follow-up to #41.

- **README Attribution**: adds an "Optional add-on tools" table crediting ai-toolkit (MIT), Fooocus (GPL-3.0), SwarmUI (MIT), and InvokeAI (Apache-2.0) with links — previously only in `docs/optional-tools.md`.
- **License fix**: SwarmUI is **MIT** per its `LICENSE.txt` (Alex "mcmonkey" Goodwin), corrected from an incorrect GPL-3.0 claim in `docs/optional-tools.md`.

All four licenses verified against the tools' own LICENSE files / package metadata.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>