### PR TITLE
comfyui-secure: dual-V100 component placement for MiniMax-H3 r2v

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Optional, installed alongside — not replacing — ComfyUI. Install + full attr
 | ComfyUI_Text_Translation | https://github.com/TFL-TFL/ComfyUI_Text_Translation | In-graph prompt translation. |
 | ComfyUI-llama-cpp_vlm | https://github.com/mickeylan/ComfyUI-llama-cpp_vlm | Runs local VLM (GGUF + mmproj) inference inside ComfyUI for image captioning/analysis. |
 | ComfyUI-Login | https://github.com/liusida/ComfyUI-Login | Password authentication for the locked ComfyUI instance. |
+| ComfyUI-MultiGPU | https://github.com/pollockjj/ComfyUI-MultiGPU | Per-loader device selection so a big model's components can be split across both V100s (e.g. MiniMax-H3: text encoder + VAEs on idx1, diffusion model resident on idx2 — no PCIe offload). |
 | llama-cpp-python (JamePeng fork) | https://github.com/JamePeng/llama-cpp-python | Python bindings backing the VLM node; built from source (v0.3.40) for sm_60/sm_70. |
 
 ### Tooling & infrastructure

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -371,6 +371,35 @@ sudo systemctl start comfyui-open comfyui-secure server-status
 Leaving ComfyUI running is normal (image gen stays instant); just know the V100s won't
 deep-idle until their CUDA context is gone.
 
+### Dual-V100 for oversized ComfyUI models (component placement)
+Some models don't fit one 32 GB V100 even quantized. The MiniMax-H3 reference-to-video
+graph loads a **21.6 GB** int8 diffusion model **+** a **15 GB** Qwen3-VL text encoder **+**
+~5 GB of VAEs — ~42 GB total. On one card ComfyUI evicts weights to CPU and streams them
+back **every sampling step** (measured ~4 GB/s `rxpci` on the slow PCIe gen3 x8 bus), which
+dominates wall-clock. The fix is to **place whole components on separate cards** (no model is
+split — see the no-NVLink rule of thumb: split by component, never one model across cards).
+
+`comfyui-secure` is pinned to `CUDA_VISIBLE_DEVICES=2,1` (`CUDA_DEVICE_ORDER=PCI_BUS_ID` →
+`cuda:0` = idx2, `cuda:1` = idx1) and runs `--reserve-vram 2` (low, so the diffusion model
+stays fully resident on idx2). The [ComfyUI-MultiGPU](https://github.com/pollockjj/ComfyUI-MultiGPU)
+node pack adds a `device` dropdown to the loaders. In the workflow:
+
+| Loader | Swap to | device |
+|--------|---------|--------|
+| UNETLoader (diffusion) | `UNETLoaderMultiGPU` | `cuda:0` (idx2) |
+| CLIPLoader (text encoder) | `CLIPLoaderMultiGPU` | `cuda:1` (idx1) |
+| VAELoader (video + audio) | `VAELoaderMultiGPU` | `cuda:1` (idx1) |
+
+This keeps the denoising loop 100% on idx2 with **no PCIe offload** (`rxpci` drops from
+~4 GB/s to ~20 MB/s; idx2 goes fully compute-bound). Only a one-time text-encoder→sampler
+handoff crosses the bus. Cards work **sequentially** (TE encodes, then idx2 denoises) — the
+win is HBM capacity, not concurrent compute.
+
+> **Pre-flight (manual recipe):** idx1 also serves LLMs and hosts `comfyui-open`. Before a
+> dual-GPU run, free idx1: `sudo systemctl stop comfyui-open` and unload idx1's llama-swap
+> models, then confirm `nvidia-smi` shows idx1 near-empty. Normal (non-MultiGPU) workflows
+> are unaffected — they default to `cuda:0` (idx2) as before.
+
 ### Quiet-hours deep-idle window
 The `server-status` service can run an optional overnight window that drops the box to the
 true cold-idle floor (~73 W GPU vs ~103 W warm; see the README Power-usage tables). On

--- a/scripts/comfyui-secure.service
+++ b/scripts/comfyui-secure.service
@@ -12,9 +12,16 @@ WorkingDirectory=/srv/ai/comfyui
 # Deterministic GPU numbering so CUDA_VISIBLE_DEVICES maps to the same physical
 # cards as nvidia-smi (idx0=P100, idx1/2=V100).
 Environment=CUDA_DEVICE_ORDER=PCI_BUS_ID
-# LOCKED instance: pin to V100 #2 (idx2 = the `chat` card) so it never contends
-# for GPU with the OPEN instance (idx1).
-Environment=CUDA_VISIBLE_DEVICES=2
+# Primary card = V100 #2 (idx2 = the `chat` card). idx1 is ALSO made visible as a
+# secondary so heavy jobs can park a component (e.g. the MiniMax-H3 ~15 GB text
+# encoder) on it via ComfyUI-MultiGPU loaders and keep the diffusion model fully
+# resident on idx2 (no CPU/PCIe offload). Order matters with CUDA_DEVICE_ORDER
+# above: cuda:0 = idx2 (diffusion home, unchanged default), cuda:1 = idx1.
+# MANUAL RECIPE for dual-GPU jobs: idx1 normally serves LLMs (coding/gemma-31b/
+# chat-uncensored) and hosts comfyui-open, so BEFORE such a run stop comfyui-open
+# and clear idx1's llama-swap models, then target cuda:1 for the text encoder.
+# Non-MultiGPU workflows are unaffected: they default to cuda:0 (idx2) as before.
+Environment=CUDA_VISIBLE_DEVICES=2,1
 # Reduce allocator fragmentation so large activation spikes (e.g. MiniMax-H3 DiT
 # attention on longer clips) can reuse reserved-but-unallocated VRAM instead of
 # OOMing. See the H3 OOM analysis: 2.44 GiB alloc failed with ~2.76 GiB reserved
@@ -33,8 +40,15 @@ Environment=FREE_GPU_RESTORE=chat
 # The PASSWORD lives at /srv/ai/comfyui/login/PASSWORD (delete it to reset).
 # Shared: models/, custom_nodes/, --user-directory (workflows + settings).
 # Separate: output/input/temp (isolates assets from the open instance).
+#
+# --reserve-vram 2: keep this LOW. The big MiniMax r2v models no longer share
+# idx2 — text encoder + VAEs go to idx1 via ComfyUI-MultiGPU loaders — so the
+# 21.6 GB diffusion model fits fully resident on idx2 with room to spare. A
+# large reserve would force ComfyUI to evict+stream diffusion weights from CPU
+# every sampling step (~4 GB/s rxpci PCIe tax). Bump only if idx2 OOMs.
 ExecStart=/srv/ai/venvs/comfyui/bin/python /srv/ai/comfyui/main.py \
   --listen 0.0.0.0 --port 8189 \
+  --reserve-vram 2 \
   --extra-model-paths-config /srv/ai/scripts/comfyui-secure-extra-paths.yaml \
   --output-directory /srv/ai/comfyui/output-secure \
   --input-directory /srv/ai/comfyui/input-secure \


### PR DESCRIPTION
## What
Enable running oversized ComfyUI models (that don't fit one 32 GB V100) across **both** V100s via component placement, using the newly installed [ComfyUI-MultiGPU](https://github.com/pollockjj/ComfyUI-MultiGPU) node pack.

Motivating case: the MiniMax-H3 reference-to-video graph loads ~42 GB of models (21.6 GB int8 diffusion + 15 GB Qwen3-VL text encoder + ~5 GB VAEs). On one card ComfyUI evicted weights to CPU and streamed them back **every sampling step** — measured **~4 GB/s rxpci** on the slow PCIe gen3 x8 bus, dominating wall-clock.

## Change
- `scripts/comfyui-secure.service`: `CUDA_VISIBLE_DEVICES=2` → `2,1` (with `CUDA_DEVICE_ORDER=PCI_BUS_ID`: cuda:0=idx2, cuda:1=idx1), and `--reserve-vram 8` → `2`. The low reserve is essential — once components are split, a large reserve on idx2 *re-introduces* the offload it was meant to avoid.
- `README.md`: attribute ComfyUI-MultiGPU (pollockjj).
- `docs/server-setup.md`: 'Dual-V100 for oversized ComfyUI models (component placement)' recipe + manual idx1 pre-flight.

Workflow loader swaps: diffusion → `UNETLoaderMultiGPU` (cuda:0), text encoder → `CLIPLoaderMultiGPU` (cuda:1), VAEs → `VAELoaderMultiGPU` (cuda:1).

## Verified live (2026-08-10)
| Metric (idx2, sampling) | reserve 8 | reserve 2 |
|---|---|---|
| rxpci | ~4,173 MB/s | **~20 MB/s** |
| mem resident | 26.2 GB | **30.7 GB** (full model) |
| power | 158 W | **180 W** (compute-bound) |

idx1 holds TE+VAEs (28.8 GB, idle during sampling). No per-step PCIe offload; the denoising loop stays 100% on idx2.

## Notes
- Normal (non-MultiGPU) workflows are unaffected — they default to cuda:0 (idx2).
- Applying to the live box needs root: `sudo install -m0644 scripts/comfyui-secure.service /etc/systemd/system/` + `daemon-reload` + `restart comfyui-secure` (already done on the box).