### PR TITLE
Open WebUI: daily GC for orphaned uploaded images

### DIFF
--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -950,6 +950,18 @@ family accounts under Admin → Users. Web search is pre-wired (`ENABLE_WEB_SEAR
 `WEB_SEARCH_ENGINE=searxng`); enable it per-chat with the web/globe toggle. Data persists in
 the `open-webui-data` volume.
 
+**Uploaded-image GC (`open-webui-data/uploads/`):** Open WebUI (through at least v0.11)
+never garbage-collects uploads — deleting a chat leaves the image on disk **and** its row in
+`webui.db`'s `file` table, and it does **not** cascade-delete the `chat_file` join rows, so
+those orphans (and dangling join rows) accumulate forever. `scripts/openwebui-prune-uploads.py`
+(run inside the container via `scripts/openwebui-prune-uploads.sh`) finds `file` rows no longer
+referenced by any **live** chat/knowledge/note — treating a join row whose parent chat is gone
+as unreferenced — and deletes both the disk file and the DB rows. Safe by default (dry-run);
+a `--min-age-days` grace (default 7) protects freshly-uploaded, not-yet-attached files.
+Automated daily by `openwebui-prune-uploads.timer` (09:00 UTC ≈ owner's quiet hours). Manual:
+`scripts/openwebui-prune-uploads.sh` (preview) / `--apply` (delete). NB: the big `cache/`
+dir in the volume (embedding + whisper models, ~1 GB) is **not** user images — leave it.
+
 **SearXNG:** `search/formats` includes `json` (required by Open WebUI). Secret injected from
 `SEARXNG_SECRET` (settings.yml keeps the literal `ultrasecretkey` placeholder). Verified:
 `/search?q=...&format=json` returns results.

--- a/scripts/openwebui-prune-uploads.py
+++ b/scripts/openwebui-prune-uploads.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Prune orphaned Open WebUI uploads (files whose chat/knowledge reference is gone).
+
+Open WebUI (as of v0.11.0) never garbage-collects uploaded images: deleting a
+chat leaves the file on disk (uploads/) AND its row in webui.db's `file` table.
+Over time these orphans accumulate. This script finds `file` rows that are no
+longer referenced by any chat, knowledge base, or note, and (with --apply)
+deletes both the DB row and the on-disk file.
+
+Designed to run INSIDE the open-webui container (paths in the `file.path`
+column are container paths like /app/backend/data/uploads/...). The companion
+wrapper scripts/openwebui-prune-uploads.sh execs this via `docker exec`.
+
+SAFE BY DEFAULT: dry-run unless --apply is given. A grace period
+(--min-age-days, default 7) protects freshly-uploaded files that may not yet be
+attached to a saved chat.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+import time
+
+DEFAULT_DB = os.environ.get("OPENWEBUI_DB", "/app/backend/data/webui.db")
+DEFAULT_UPLOADS = os.environ.get("OPENWEBUI_UPLOADS", "/app/backend/data/uploads")
+
+
+def human(n: int) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024 or unit == "GB":
+            return f"{n:.1f}{unit}" if unit != "B" else f"{n}B"
+        n /= 1024.0
+    return f"{n:.1f}GB"
+
+
+def referenced_ids(cur: sqlite3.Cursor) -> set[str]:
+    """All file ids still referenced by a LIVE chat, knowledge base, or note.
+
+    IMPORTANT: deleting a chat in Open WebUI does NOT cascade-delete its
+    `chat_file` rows, so the join tables are full of dangling references to
+    already-deleted chats. We therefore only count a join-table reference when
+    its parent row (chat / knowledge) still exists — otherwise a deleted chat's
+    attachment would look "referenced" forever and never get pruned.
+    """
+    refs: set[str] = set()
+
+    # Authoritative join tables, but only rows whose parent still exists.
+    for table, parent, parent_key in (
+        ("chat_file", "chat", "chat_id"),
+        ("knowledge_file", "knowledge", "knowledge_id"),
+    ):
+        try:
+            q = (f"SELECT jt.file_id FROM {table} jt "
+                 f"JOIN {parent} p ON p.id = jt.{parent_key} "
+                 f"WHERE jt.file_id IS NOT NULL")
+            for (fid,) in cur.execute(q):
+                if fid:
+                    refs.add(fid)
+        except sqlite3.OperationalError:
+            pass  # table/column may differ on other schema versions
+
+    # Belt-and-suspenders: some versions embed the file id inline in chat JSON
+    # or note bodies rather than (or in addition to) the join tables. Scan the
+    # concatenated blobs of LIVE rows once and test membership per candidate id.
+    blob_parts: list[str] = []
+    for table, col in (("chat", "chat"), ("note", "data"), ("message", "content")):
+        try:
+            for (val,) in cur.execute(f"SELECT {col} FROM {table}"):
+                if val:
+                    blob_parts.append(val if isinstance(val, str) else str(val))
+        except sqlite3.OperationalError:
+            pass
+    referenced_ids._blob = "\n".join(blob_parts)  # type: ignore[attr-defined]
+    return refs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--apply", action="store_true", help="actually delete (default: dry-run)")
+    ap.add_argument("--min-age-days", type=float, default=7.0,
+                    help="only prune files older than this many days (default: 7)")
+    ap.add_argument("--db", default=DEFAULT_DB)
+    ap.add_argument("--uploads", default=DEFAULT_UPLOADS)
+    ap.add_argument("--quiet", action="store_true", help="only print the summary line")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.db):
+        print(f"ERROR: webui.db not found at {args.db}", file=sys.stderr)
+        return 2
+
+    cutoff = time.time() - args.min_age_days * 86400
+    conn = sqlite3.connect(args.db, timeout=15)
+    conn.execute("PRAGMA busy_timeout=15000")
+    cur = conn.cursor()
+
+    refs = referenced_ids(cur)
+    blob = getattr(referenced_ids, "_blob", "")
+
+    rows = cur.execute("SELECT id, filename, path, meta, created_at FROM file").fetchall()
+    total = len(rows)
+    orphans = []
+    for fid, filename, path, meta, created_at in rows:
+        if fid in refs or (fid and fid in blob):
+            continue
+        if created_at and created_at > cutoff:
+            continue  # within grace period
+        # size: prefer on-disk, fall back to meta.size
+        size = 0
+        if path and os.path.exists(path):
+            size = os.path.getsize(path)
+        else:
+            try:
+                import json
+                size = int(json.loads(meta or "{}").get("size", 0))
+            except Exception:
+                size = 0
+        orphans.append((fid, filename, path, size))
+
+    freed = sum(o[3] for o in orphans)
+    action = "DELETING" if args.apply else "would delete"
+
+    if not args.quiet:
+        for fid, filename, path, size in orphans:
+            print(f"  {action}: {filename}  ({human(size)})  id={fid}")
+
+    deleted = 0
+    if args.apply and orphans:
+        for fid, filename, path, size in orphans:
+            # Remove disk file (path column, plus any id-prefixed leftovers).
+            try:
+                if path and os.path.exists(path):
+                    os.remove(path)
+                elif os.path.isdir(args.uploads):
+                    for f in os.listdir(args.uploads):
+                        if f.startswith(fid):
+                            os.remove(os.path.join(args.uploads, f))
+            except OSError as e:
+                print(f"  WARN: could not delete file for {fid}: {e}", file=sys.stderr)
+            # Remove DB rows (file + any dangling join rows).
+            cur.execute("DELETE FROM file WHERE id = ?", (fid,))
+            for table in ("chat_file", "knowledge_file"):
+                try:
+                    cur.execute(f"DELETE FROM {table} WHERE file_id = ?", (fid,))
+                except sqlite3.OperationalError:
+                    pass
+            deleted += 1
+        conn.commit()
+
+    conn.close()
+
+    verb = "pruned" if args.apply else "orphaned (dry-run)"
+    print(f"openwebui-prune-uploads: {total} files scanned, {len(orphans)} {verb}, "
+          f"{human(freed)} {'freed' if args.apply else 'reclaimable'} "
+          f"(grace {args.min_age_days:g}d)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/openwebui-prune-uploads.service
+++ b/scripts/openwebui-prune-uploads.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Prune orphaned Open WebUI uploads (delete files whose chat/knowledge reference is gone)
+Documentation=file:/srv/ai/scripts/openwebui-prune-uploads.py
+Wants=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+# --apply actually deletes; --min-age-days 7 protects freshly-uploaded files
+# that may not yet be attached to a saved chat. Adjust the grace period as needed.
+ExecStart=/srv/ai/scripts/openwebui-prune-uploads.sh --apply --min-age-days 7 --quiet
+# Needs to reach the docker socket + delete root-owned files in the volume.
+User=root
+Nice=10
+IOSchedulingClass=idle

--- a/scripts/openwebui-prune-uploads.sh
+++ b/scripts/openwebui-prune-uploads.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Prune orphaned Open WebUI uploads by running openwebui-prune-uploads.py INSIDE
+# the open-webui container (where /app/backend/data paths are valid). The Python
+# script is piped over stdin, so nothing needs to be copied into the image.
+#
+# Usage:
+#   openwebui-prune-uploads.sh                 # dry-run (safe; shows what it would delete)
+#   openwebui-prune-uploads.sh --apply         # actually delete orphans older than 7d
+#   openwebui-prune-uploads.sh --apply --min-age-days 3
+#
+# The systemd service (openwebui-prune-uploads.service) calls this with --apply.
+set -euo pipefail
+
+CONTAINER="${OPENWEBUI_CONTAINER:-open-webui}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="${SCRIPT_DIR}/openwebui-prune-uploads.py"
+
+if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+  echo "openwebui-prune-uploads: container '$CONTAINER' is not running; skipping." >&2
+  exit 0
+fi
+
+exec docker exec -i "$CONTAINER" python3 - "$@" < "$PY"

--- a/scripts/openwebui-prune-uploads.timer
+++ b/scripts/openwebui-prune-uploads.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Daily prune of orphaned Open WebUI uploads
+Documentation=file:/srv/ai/scripts/openwebui-prune-uploads.service
+
+[Timer]
+# 09:00 UTC ~= 04:00/05:00 US-Eastern (owner's quiet hours / deep idle).
+OnCalendar=*-*-* 09:00:00
+# Run on next boot if the machine was off at the scheduled time.
+Persistent=true
+# Spread load a little; harmless for a maintenance prune.
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
Open WebUI never cleans up uploaded images. Deleting a chat leaves the file on disk (`uploads/`), its `file` table row, **and** a dangling `chat_file` join row (no cascade). On the live box, 18/24 join rows were dangling and 26 files (~13 MB) were orphaned.

This adds a daily garbage-collection job that deletes only upload files unreferenced by any **live** chat / knowledge / note.

## What's included
- `scripts/openwebui-prune-uploads.py` — core GC. Counts references only from LIVE parents (JOINs `chat_file`→`chat`, `knowledge_file`→`knowledge`, scans live chat/note/message blobs), so dangling join rows don't protect a file. Dry-run by default; `--apply`, `--min-age-days` (default 7 = grace for freshly-uploaded, not-yet-attached files), `--db`, `--uploads`, `--quiet`. Uses `busy_timeout=15000` for safe concurrent access to the live DB.
- `scripts/openwebui-prune-uploads.sh` — host wrapper; runs the script inside the `open-webui` container via `docker exec` (paths are container paths). Skips gracefully if the container isn't running.
- `scripts/openwebui-prune-uploads.service` / `.timer` — daily oneshot at 09:00 UTC (owner's quiet hours), `Persistent=true`, `RandomizedDelaySec=300`.
- `docs/server-setup.md` — runbook note in the Open WebUI section.

## Testing
- Verified against the live `webui.db`: dry-run reports 26 orphans / 13.2 MB reclaimable; the 9 kept files all map to existing chats.
- Confirmed dangling `chat_file` rows do not falsely protect orphaned files.

## Install (needs sudo — done on the box)
```
sudo cp scripts/openwebui-prune-uploads.{service,timer} /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl enable --now openwebui-prune-uploads.timer
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>