### PR TITLE
MiniMax-H3 native fp16: status-page --fp16-unet toggle + node attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,12 +357,19 @@ Optional, installed alongside — not replacing — ComfyUI. Install + full attr
 |---------|------|---------------|
 | ComfyUI-Manager | https://github.com/ltdrdata/ComfyUI-Manager | Custom-node management and reproducible install snapshots. |
 | ComfyUI-GGUF | https://github.com/city96/ComfyUI-GGUF | Loads GGUF-quantized diffusion models (e.g. Qwen-Image-Edit, FLUX.2) that don't fit as fp8 on the V100. |
+| ComfyUI-H3-Multishot | https://github.com/jlucasmcrell/ComfyUI-H3-Multishot | Teaches ComfyUI-GGUF the `minimax_h3` architecture (so H3 GGUFs load) and provides the H3 model/CLIP loaders used for MiniMax-H3 video. |
+| minimax-h3-fp16-fix | https://github.com/Amduraznak/minimax-h3-fp16-fix | One-file node by **Amduraznak** that runs MiniMax-H3 at native fp16 on Volta (V100, no bf16) — keeps the 3 fp16-overflow spots in fp32 so `--fp16-unet` stops black-framing. **~3.5× faster** on our secure V100 (38m32s → 10m53s on a GGUF clip). |
 | ComfyUI-KJNodes | https://github.com/kijai/ComfyUI-KJNodes | Utility nodes used across image/video workflows. |
 | ComfyUI-WanVideoWrapper | https://github.com/kijai/ComfyUI-WanVideoWrapper | WAN text/image-to-video generation with block-swap and VAE tiling for the 32 GB V100. |
+| ComfyUI-MiniMax-H3-Turbo | https://github.com/larryvrh/ComfyUI-MiniMax-H3-Turbo | MiniMax-H3 video nodes + 4-step turbo LoRA sampler used by the native (int8) H3 workflows. |
+| ComfyUI-MMAudio | https://github.com/kijai/ComfyUI-MMAudio | Video-to-audio Foley: generates sound matched to a generated clip (used in the Wan+MMAudio and add-audio-to-video workflows). |
+| ComfyUI-MultiGPU | https://github.com/pollockjj/ComfyUI-MultiGPU | Per-component device placement so oversized H3 models (DiT + Qwen3-VL text encoder + VAEs) fit across both V100s. |
+| ComfyUI-VideoHelperSuite | https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite | Video load/combine/preview nodes underpinning the video-gen workflows. |
 | ComfyUI-Frame-Interpolation | https://github.com/Fannovel16/ComfyUI-Frame-Interpolation | Frame interpolation for generated video. |
 | rgthree-comfy | https://github.com/rgthree/rgthree-comfy | Quality-of-life nodes incl. the Power Lora Loader used by style workflows. |
 | ComfyUI-Custom-Scripts | https://github.com/pythongosssss/ComfyUI-Custom-Scripts | Editor/UX enhancements for the ComfyUI graph. |
 | ComfyUI-Easy-Use | https://github.com/yolain/ComfyUI-Easy-Use | Simplified/composite nodes for building workflows. |
+| comfyui-krea2edit | https://github.com/lbouaraba/comfyui-krea2edit | Nodes for the Krea-2 image-edit workflows. |
 | ComfyUI_Text_Translation | https://github.com/TFL-TFL/ComfyUI_Text_Translation | In-graph prompt translation. |
 | ComfyUI-llama-cpp_vlm | https://github.com/mickeylan/ComfyUI-llama-cpp_vlm | Runs local VLM (GGUF + mmproj) inference inside ComfyUI for image captioning/analysis. |
 | ComfyUI-Login | https://github.com/liusida/ComfyUI-Login | Password authentication for the locked ComfyUI instance. |

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1340,9 +1340,47 @@ sudo /srv/ai/venvs/comfyui/bin/python scripts/comfyui-power-sweep.py \
   --label video --workflow ~/your_video_api.json --runs 2
 ```
 
-## Qwen3.8-27B migration — `coding` + `big` benchmark suite (2026-08-15)
+## MiniMax-H3 video — native fp16 on V100 (`--fp16-unet` + overflow fix, 2026-08-27)
 
-We migrated the `coding` and `big` slots from Qwen3.6-27B to **Qwen3.8-27B**
+H3's DiT only whitelists bf16/fp32, so on Volta (no bf16) ComfyUI silently casts to **fp32** and
+crawls. Forcing `--fp16-unet` alone runs on fp16 tensor cores but **black-frames** — three spots in
+the H3 DiT overflow fp16's range (text-conditioning projection, attention-sink residual rows, a
+couple of block output projections). The one-file node
+`custom_nodes/minimax_h3_fp16_fix.py` (from `Amduraznak/minimax-h3-fp16-fix`, MIT) keeps just those
+spots in fp32/rescaled while everything else runs fp16; it self-disables unless `--fp16-unet` is set.
+
+Measured on our stack (ComfyUI v0.30.1, torch 2.6.0+cu124, dual-V100 visible, `fl2va-curve-Q5_1`
+GGUF via **ComfyUI-H3-Multishot** + ComfyUI-GGUF, 25-frame clip):
+
+| resolution | fp32 fallback | `--fp16-unet` **no fix** | `--fp16-unet` **+ fix** | speedup | frames |
+|-----------:|--------------:|-------------------------:|------------------------:|--------:|:------|
+| 512×512 | 14.88 s/it | 3.70 s/it | **4.05 s/it** | **3.67×** | black w/o fix, valid w/ |
+| 768×768 | 35.34 s/it | — | **9.15 s/it** | **3.86×** | valid (mean 168) |
+
+- **The fix is mandatory on a non-int8 model**: without it `--fp16-unet` gives pure black (`max=0`);
+  with it the DiT runs native fp16 (`model weight dtype torch.float16, manual cast: None`) and
+  output is clean. The ~9 % overhead vs the (broken) no-fix run is the fp32 islands — the correct
+  trade.
+- **Speedup grows with resolution** (compute-bound scaling: 3.67× → 3.86×); the Reddit-reported ~11×
+  was at 1120×768 on a single card where compute fully dominates.
+
+**Real-world confirmation (secure slot, single V100 idx2, 2026-08-27):** a full production clip run
+back-to-back on the `comfyui-secure` instance via the status-page fp16 toggle — same GGUF workflow,
+flag flipped between runs — gave **10m53s with `--fp16-unet` (native fp16, `manual cast: None`)** vs
+**38m32s in the fp32 fallback (`manual cast: torch.float32`)**, i.e. **3.54×**, matching the s/it
+benchmark above. Times read straight from `journalctl -u comfyui-secure` (`Prompt executed in …`).
+
+- **Model format matters more than the fix.** Our earlier **int8_convrot** pruned/turbo weights only
+  gained **1.28×** from the fix, because int8 GEMM dequantizes to fp32 accumulate and never reaches
+  fp16 tensor cores regardless of `--fp16-unet`. A **GGUF** (or stock bf16) model dequantizes to the
+  compute dtype, so it actually reaches native fp16 — that is what unlocks the ~3.9×.
+
+`--fp16-unet` is a per-instance ComfyUI flag affecting **every** model on that instance, so it ships
+**off** and is flipped per-session from the status page's per-ComfyUI **fp16** checkbox (editable only
+while the instance is stopped; auto-resets off on reboot / quiet-hours end). See
+`docs/server-setup.md` → "ComfyUI native-fp16 toggle".
+
+
 (unsloth GGUFs, `general.architecture=qwen35` — drop-in on llama.cpp build 9850,
 MTP `nextn` head embedded in the main GGUF). `chat` stays Qwen3.6-35B-A3B MoE.
 This section records the full validation pass (throughput, MTP, GSM8K quality,

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -412,6 +412,44 @@ together (what quiet hours uses). These reuse the scoped sudoers rule and are ga
 sudoers file grants both the pair command (quiet hours) and the single-unit commands
 (independent buttons).
 
+#### ComfyUI native-fp16 toggle (`--fp16-unet`, per instance)
+
+Each ComfyUI row carries a small **fp16** checkbox next to its Start/Stop button. Ticking it
+launches that instance with `--fp16-unet`, which runs the UNet/DiT on the V100's fp16 tensor
+cores instead of the fp32 fallback. On **MiniMax-H3 GGUF** models this is **~3.9×** faster
+(35.3→9.2 s/it at 768²; native fp16 = `manual cast: None`) — but it needs the
+`custom_nodes/minimax_h3_fp16_fix.py` node installed, or H3 renders come out **pure black**
+from fp16 overflow (the fix keeps the 3 overflow-prone spots in fp32; it self-disables when
+`--fp16-unet` is off). See the H3 fp16 section in `docs/benchmarking.md`.
+
+**`--fp16-unet` is a per-instance flag that affects EVERY model on that ComfyUI instance** —
+only MiniMax-H3 is validated here — so it is **off by default** and meant to be flipped
+per-session:
+
+- The checkbox is **editable only while the instance is stopped**. Once you start it, the
+  flag is baked into the process args and the checkbox locks to show the live state (stop the
+  instance to change it again). `POST /actions/comfyui-fp16?unit=comfyui-open&enabled=true`.
+- The flag is stored as a tiny env file on **tmpfs** (`/run/comfyui-fp16/<label>.env`, read by
+  the unit via `EnvironmentFile=-`), so it **auto-resets to off on every reboot** — native fp16
+  never silently persists. Quiet-hours end also clears it before the nightly restart, so the
+  daily instances always come back up in the safe fp32 mode.
+
+One-time setup (units + tmpfs dir + service):
+```bash
+# 1) install the tmpfs runtime dir (default-off on boot):
+sudo cp scripts/comfyui-fp16.tmpfiles /etc/tmpfiles.d/comfyui-fp16.conf
+sudo systemd-tmpfiles --create /etc/tmpfiles.d/comfyui-fp16.conf
+
+# 2) install the updated units (add EnvironmentFile + $COMFYUI_EXTRA_ARGS):
+sudo cp scripts/comfyui-open.service scripts/comfyui-secure.service /etc/systemd/system/
+sudo systemctl daemon-reload
+
+# 3) pick up the dashboard checkbox:
+sudo systemctl restart server-status
+```
+The toggle needs no extra sudoers entry (the status service writes the `/run` file as its own
+user); only Start/Stop go through the existing scoped rule.
+
 #### On-demand creative-tool services (Fooocus / SwarmUI / InvokeAI)
 The optional image-gen tools each hold VRAM on a V100 while running and can OOM the
 LLM/ComfyUI tiers if left up, so they are **not enabled at boot** — you start/stop them

--- a/scripts/build-mmaudio-workflows.js
+++ b/scripts/build-mmaudio-workflows.js
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+// Builds two ComfyUI workflow JSONs (frontend graph format):
+//   1) wan22-i2v-mmaudio.json      - native Wan2.2 14B I2V (dual high/low noise) + MMAudio Foley
+//   2) add-audio-to-video-mmaudio.json - load an existing video and add MMAudio-generated sound
+// Model filenames match what is on disk under /srv/ai/comfyui/models.
+// fp16 MMAudio models are mandatory on Volta sm_70 (no fp8).
+const fs = require('fs');
+const path = require('path');
+
+function Builder() {
+  this.nodes = [];
+  this.links = [];
+  this.nid = 0;
+  this.lid = 0;
+}
+Builder.prototype.node = function (type, opts) {
+  opts = opts || {};
+  const id = ++this.nid;
+  const n = {
+    id: id,
+    type: type,
+    pos: opts.pos || [0, 0],
+    size: opts.size || [300, 120],
+    flags: {},
+    order: this.nodes.length,
+    mode: 0,
+    inputs: (opts.inputs || []).map(i => ({ name: i.name, type: i.type, link: null, ...(i.shape ? { shape: i.shape } : {}) })),
+    outputs: (opts.outputs || []).map(o => ({ name: o.name, type: o.type, links: [], slot_index: undefined })),
+    properties: { 'Node name for S&R': type },
+    widgets_values: opts.widgets_values !== undefined ? opts.widgets_values : [],
+  };
+  if (opts.title) n.title = opts.title;
+  this.nodes.push(n);
+  return n;
+};
+// connect(srcNode, srcSlotIdx, dstNode, dstSlotIdx)
+Builder.prototype.connect = function (src, sslot, dst, dslot) {
+  const lid = ++this.lid;
+  const type = src.outputs[sslot].type;
+  this.links.push([lid, src.id, sslot, dst.id, dslot, type]);
+  src.outputs[sslot].links.push(lid);
+  src.outputs[sslot].slot_index = sslot;
+  dst.inputs[dslot].link = lid;
+  return lid;
+};
+Builder.prototype.dump = function (extraNote) {
+  return {
+    last_node_id: this.nid,
+    last_link_id: this.lid,
+    nodes: this.nodes,
+    links: this.links,
+    groups: [],
+    config: {},
+    extra: {},
+    version: 0.4,
+  };
+};
+
+// ---- shared MMAudio model filenames ----
+const MM_MAIN = 'mmaudio_large_44k_v2_fp16.safetensors';
+const MM_VAE = 'mmaudio_vae_44k_fp16.safetensors';
+const MM_SYNC = 'mmaudio_synchformer_fp16.safetensors';
+const MM_CLIP = 'apple_DFN5B-CLIP-ViT-H-14-384_fp16.safetensors';
+
+// ==========================================================================
+// Workflow 1: Wan 2.2 14B I2V (dual model) + MMAudio
+// ==========================================================================
+function buildWan() {
+  const b = new Builder();
+  const X = c => c * 360; // column spacing
+
+  const loadImg = b.node('LoadImage', {
+    pos: [X(0), 40], size: [320, 320],
+    outputs: [{ name: 'IMAGE', type: 'IMAGE' }, { name: 'MASK', type: 'MASK' }],
+    widgets_values: ['example.png', 'image'],
+    title: '1. Start image',
+  });
+  const clip = b.node('CLIPLoader', {
+    pos: [X(0), 400], size: [320, 110],
+    outputs: [{ name: 'CLIP', type: 'CLIP' }],
+    widgets_values: ['umt5_xxl_fp8_e4m3fn_scaled.safetensors', 'wan', 'default'],
+  });
+  const vae = b.node('VAELoader', {
+    pos: [X(0), 540], size: [320, 60],
+    outputs: [{ name: 'VAE', type: 'VAE' }],
+    widgets_values: ['wan_2.1_vae.safetensors'],
+  });
+  const unetHi = b.node('UNETLoader', {
+    pos: [X(0), 630], size: [320, 90],
+    outputs: [{ name: 'MODEL', type: 'MODEL' }],
+    widgets_values: ['wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors', 'default'],
+    title: 'High-noise model',
+  });
+  const unetLo = b.node('UNETLoader', {
+    pos: [X(0), 750], size: [320, 90],
+    outputs: [{ name: 'MODEL', type: 'MODEL' }],
+    widgets_values: ['wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors', 'default'],
+    title: 'Low-noise model',
+  });
+
+  const posText = b.node('CLIPTextEncode', {
+    pos: [X(1), 40], size: [360, 130],
+    inputs: [{ name: 'clip', type: 'CLIP' }],
+    outputs: [{ name: 'CONDITIONING', type: 'CONDITIONING' }],
+    widgets_values: ['a cinematic shot, the subject moves naturally, smooth camera motion, high detail'],
+    title: 'Positive prompt',
+  });
+  const negText = b.node('CLIPTextEncode', {
+    pos: [X(1), 200], size: [360, 130],
+    inputs: [{ name: 'clip', type: 'CLIP' }],
+    outputs: [{ name: 'CONDITIONING', type: 'CONDITIONING' }],
+    widgets_values: ['色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走'],
+    title: 'Negative prompt',
+  });
+  const shiftHi = b.node('ModelSamplingSD3', {
+    pos: [X(1), 360], size: [300, 60],
+    inputs: [{ name: 'model', type: 'MODEL' }],
+    outputs: [{ name: 'MODEL', type: 'MODEL' }],
+    widgets_values: [8.0],
+    title: 'Shift (high)',
+  });
+  const shiftLo = b.node('ModelSamplingSD3', {
+    pos: [X(1), 450], size: [300, 60],
+    inputs: [{ name: 'model', type: 'MODEL' }],
+    outputs: [{ name: 'MODEL', type: 'MODEL' }],
+    widgets_values: [8.0],
+    title: 'Shift (low)',
+  });
+
+  const i2v = b.node('WanImageToVideo', {
+    pos: [X(2), 40], size: [320, 220],
+    inputs: [
+      { name: 'positive', type: 'CONDITIONING' },
+      { name: 'negative', type: 'CONDITIONING' },
+      { name: 'vae', type: 'VAE' },
+      { name: 'clip_vision_output', type: 'CLIP_VISION_OUTPUT', shape: 7 },
+      { name: 'start_image', type: 'IMAGE', shape: 7 },
+    ],
+    outputs: [
+      { name: 'positive', type: 'CONDITIONING' },
+      { name: 'negative', type: 'CONDITIONING' },
+      { name: 'latent', type: 'LATENT' },
+    ],
+    widgets_values: [832, 480, 81, 1], // width,height,length,batch_size
+    title: 'WanImageToVideo (832x480, 81f)',
+  });
+
+  const kHi = b.node('KSamplerAdvanced', {
+    pos: [X(3), 40], size: [320, 340],
+    inputs: [
+      { name: 'model', type: 'MODEL' },
+      { name: 'positive', type: 'CONDITIONING' },
+      { name: 'negative', type: 'CONDITIONING' },
+      { name: 'latent_image', type: 'LATENT' },
+    ],
+    outputs: [{ name: 'LATENT', type: 'LATENT' }],
+    // add_noise,noise_seed,steps,cfg,sampler,scheduler,start_at,end_at,return_leftover
+    widgets_values: ['enable', 0, 20, 3.5, 'euler', 'simple', 0, 10, 'enable'],
+    title: 'KSampler high (0-10)',
+  });
+  const kLo = b.node('KSamplerAdvanced', {
+    pos: [X(4), 40], size: [320, 340],
+    inputs: [
+      { name: 'model', type: 'MODEL' },
+      { name: 'positive', type: 'CONDITIONING' },
+      { name: 'negative', type: 'CONDITIONING' },
+      { name: 'latent_image', type: 'LATENT' },
+    ],
+    outputs: [{ name: 'LATENT', type: 'LATENT' }],
+    widgets_values: ['disable', 0, 20, 3.5, 'euler', 'simple', 10, 10000, 'disable'],
+    title: 'KSampler low (10-end)',
+  });
+
+  const dec = b.node('VAEDecode', {
+    pos: [X(5), 40], size: [220, 60],
+    inputs: [{ name: 'samples', type: 'LATENT' }, { name: 'vae', type: 'VAE' }],
+    outputs: [{ name: 'IMAGE', type: 'IMAGE' }],
+  });
+
+  // MMAudio
+  const mmModel = b.node('MMAudioModelLoader', {
+    pos: [X(5), 160], size: [340, 90],
+    outputs: [{ name: 'mmaudio_model', type: 'MMAUDIO_MODEL' }],
+    widgets_values: [MM_MAIN, 'fp16'],
+  });
+  const mmFeat = b.node('MMAudioFeatureUtilsLoader', {
+    pos: [X(5), 280], size: [340, 170],
+    inputs: [{ name: 'bigvgan_vocoder_model', type: 'VOCODER_MODEL', shape: 7 }],
+    outputs: [{ name: 'mmaudio_featureutils', type: 'MMAUDIO_FEATUREUTILS' }],
+    widgets_values: [MM_VAE, MM_SYNC, MM_CLIP, '44k', 'fp16'],
+  });
+  const mmSamp = b.node('MMAudioSampler', {
+    pos: [X(6), 40], size: [380, 300],
+    inputs: [
+      { name: 'mmaudio_model', type: 'MMAUDIO_MODEL' },
+      { name: 'feature_utils', type: 'MMAUDIO_FEATUREUTILS' },
+      { name: 'images', type: 'IMAGE', shape: 7 },
+    ],
+    outputs: [{ name: 'audio', type: 'AUDIO' }],
+    // duration,steps,cfg,seed,prompt,negative_prompt,mask_away_clip,force_offload
+    widgets_values: [5.06, 25, 4.5, 0, 'footsteps, ambient room tone, natural sound', 'music, voice, speech', false, true],
+    title: 'MMAudio (81f/16fps = 5.06s)',
+  });
+  const combine = b.node('VHS_VideoCombine', {
+    pos: [X(7), 40], size: [420, 380],
+    inputs: [
+      { name: 'images', type: 'IMAGE' },
+      { name: 'audio', type: 'AUDIO', shape: 7 },
+      { name: 'meta_batch', type: 'VHS_BatchManager', shape: 7 },
+      { name: 'vae', type: 'VAE', shape: 7 },
+    ],
+    outputs: [{ name: 'Filenames', type: 'VHS_FILENAMES' }],
+    widgets_values: {
+      frame_rate: 16, loop_count: 0, filename_prefix: 'Wan22_MMAudio',
+      format: 'video/h264-mp4', pix_fmt: 'yuv420p', crf: 19,
+      save_metadata: true, pingpong: false, save_output: true,
+    },
+    title: 'Combine video + audio -> mp4',
+  });
+
+  // wire
+  b.connect(clip, 0, posText, 0);
+  b.connect(clip, 0, negText, 0);
+  b.connect(unetHi, 0, shiftHi, 0);
+  b.connect(unetLo, 0, shiftLo, 0);
+  b.connect(posText, 0, i2v, 0);
+  b.connect(negText, 0, i2v, 1);
+  b.connect(vae, 0, i2v, 2);
+  b.connect(loadImg, 0, i2v, 4); // start_image
+  // high sampler
+  b.connect(shiftHi, 0, kHi, 0);
+  b.connect(i2v, 0, kHi, 1);
+  b.connect(i2v, 1, kHi, 2);
+  b.connect(i2v, 2, kHi, 3);
+  // low sampler (continues from high latent)
+  b.connect(shiftLo, 0, kLo, 0);
+  b.connect(i2v, 0, kLo, 1);
+  b.connect(i2v, 1, kLo, 2);
+  b.connect(kHi, 0, kLo, 3);
+  // decode
+  b.connect(kLo, 0, dec, 0);
+  b.connect(vae, 0, dec, 1);
+  // mmaudio
+  b.connect(mmModel, 0, mmSamp, 0);
+  b.connect(mmFeat, 0, mmSamp, 1);
+  b.connect(dec, 0, mmSamp, 2);
+  // combine
+  b.connect(dec, 0, combine, 0);
+  b.connect(mmSamp, 0, combine, 1);
+
+  return b.dump();
+}
+
+// ==========================================================================
+// Workflow 2: Add audio to an existing video
+// ==========================================================================
+function buildAddAudio() {
+  const b = new Builder();
+  const X = c => c * 380;
+
+  const loadVid = b.node('VHS_LoadVideo', {
+    pos: [X(0), 40], size: [360, 500],
+    inputs: [
+      { name: 'meta_batch', type: 'VHS_BatchManager', shape: 7 },
+      { name: 'vae', type: 'VAE', shape: 7 },
+    ],
+    outputs: [
+      { name: 'IMAGE', type: 'IMAGE' },
+      { name: 'frame_count', type: 'INT' },
+      { name: 'audio', type: 'AUDIO' },
+      { name: 'video_info', type: 'VHS_VIDEOINFO' },
+    ],
+    // video,force_rate,custom_width,custom_height,frame_load_cap,skip_first_frames,select_every_nth
+    widgets_values: {
+      video: 'input.mp4', force_rate: 0, custom_width: 0, custom_height: 0,
+      frame_load_cap: 0, skip_first_frames: 0, select_every_nth: 1,
+    },
+    title: '1. Load your video',
+  });
+  const info = b.node('VHS_VideoInfo', {
+    pos: [X(1), 40], size: [280, 220],
+    inputs: [{ name: 'video_info', type: 'VHS_VIDEOINFO' }],
+    outputs: [
+      { name: 'source_fps', type: 'FLOAT' },
+      { name: 'source_frame_count', type: 'INT' },
+      { name: 'source_duration', type: 'FLOAT' },
+      { name: 'source_width', type: 'INT' },
+      { name: 'source_height', type: 'INT' },
+      { name: 'loaded_fps', type: 'FLOAT' },
+      { name: 'loaded_frame_count', type: 'INT' },
+      { name: 'loaded_duration', type: 'FLOAT' },
+      { name: 'loaded_width', type: 'INT' },
+      { name: 'loaded_height', type: 'INT' },
+    ],
+    widgets_values: {},
+  });
+
+  const mmModel = b.node('MMAudioModelLoader', {
+    pos: [X(1), 300], size: [340, 90],
+    outputs: [{ name: 'mmaudio_model', type: 'MMAUDIO_MODEL' }],
+    widgets_values: [MM_MAIN, 'fp16'],
+  });
+  const mmFeat = b.node('MMAudioFeatureUtilsLoader', {
+    pos: [X(1), 420], size: [340, 170],
+    inputs: [{ name: 'bigvgan_vocoder_model', type: 'VOCODER_MODEL', shape: 7 }],
+    outputs: [{ name: 'mmaudio_featureutils', type: 'MMAUDIO_FEATUREUTILS' }],
+    widgets_values: [MM_VAE, MM_SYNC, MM_CLIP, '44k', 'fp16'],
+  });
+
+  const mmSamp = b.node('MMAudioSampler', {
+    pos: [X(2), 40], size: [380, 320],
+    inputs: [
+      { name: 'mmaudio_model', type: 'MMAUDIO_MODEL' },
+      { name: 'feature_utils', type: 'MMAUDIO_FEATUREUTILS' },
+      { name: 'images', type: 'IMAGE', shape: 7 },
+      { name: 'duration', type: 'FLOAT', widget: { name: 'duration' }, shape: 7 },
+    ],
+    outputs: [{ name: 'audio', type: 'AUDIO' }],
+    widgets_values: [5.0, 25, 4.5, 0, 'match the on-screen action, natural sound effects', 'music, voice, speech', false, true],
+    title: 'MMAudio (duration from video)',
+  });
+  // duration input is fed by link; keep widget value as fallback
+
+  const preview = b.node('PreviewAudio', {
+    pos: [X(3), 40], size: [320, 90],
+    inputs: [{ name: 'audio', type: 'AUDIO' }],
+    outputs: [],
+    widgets_values: [null],
+  });
+  const combine = b.node('VHS_VideoCombine', {
+    pos: [X(3), 180], size: [420, 380],
+    inputs: [
+      { name: 'images', type: 'IMAGE' },
+      { name: 'audio', type: 'AUDIO', shape: 7 },
+      { name: 'meta_batch', type: 'VHS_BatchManager', shape: 7 },
+      { name: 'vae', type: 'VAE', shape: 7 },
+      { name: 'frame_rate', type: 'FLOAT', widget: { name: 'frame_rate' }, shape: 7 },
+    ],
+    outputs: [{ name: 'Filenames', type: 'VHS_FILENAMES' }],
+    widgets_values: {
+      frame_rate: 16, loop_count: 0, filename_prefix: 'MMAudio_added',
+      format: 'video/h264-mp4', pix_fmt: 'yuv420p', crf: 19,
+      save_metadata: true, pingpong: false, save_output: true,
+    },
+    title: 'Re-mux video + new audio',
+  });
+
+  // wire
+  b.connect(loadVid, 3, info, 0);        // video_info -> info
+  b.connect(loadVid, 0, mmSamp, 2);      // IMAGE -> images
+  b.connect(info, 7, mmSamp, 3);         // loaded_duration -> duration
+  b.connect(mmModel, 0, mmSamp, 0);
+  b.connect(mmFeat, 0, mmSamp, 1);
+  b.connect(mmSamp, 0, preview, 0);
+  b.connect(loadVid, 0, combine, 0);     // IMAGE -> images
+  b.connect(mmSamp, 0, combine, 1);      // audio
+  b.connect(info, 5, combine, 4);        // loaded_fps -> frame_rate
+
+  return b.dump();
+}
+
+const outDir = process.argv[2] || '.';
+const w1 = buildWan();
+const w2 = buildAddAudio();
+fs.writeFileSync(path.join(outDir, 'wan22-i2v-mmaudio.json'), JSON.stringify(w1, null, 2));
+fs.writeFileSync(path.join(outDir, 'add-audio-to-video-mmaudio.json'), JSON.stringify(w2, null, 2));
+console.log('wrote wan22-i2v-mmaudio.json (' + w1.nodes.length + ' nodes, ' + w1.links.length + ' links)');
+console.log('wrote add-audio-to-video-mmaudio.json (' + w2.nodes.length + ' nodes, ' + w2.links.length + ' links)');

--- a/scripts/comfyui-fp16.tmpfiles
+++ b/scripts/comfyui-fp16.tmpfiles
@@ -1,0 +1,10 @@
+# Runtime dir for the ComfyUI per-instance native-fp16 toggle (--fp16-unet),
+# driven from the server status page. Living on tmpfs (/run) means it is wiped on
+# every boot, so native fp16 always defaults to OFF after a reboot — no stale
+# "enabled" flag can survive. Owned by the status-service / ComfyUI user (brad)
+# so the status service can write the per-unit <label>.env files and the ComfyUI
+# units can read them via EnvironmentFile=-/run/comfyui-fp16/<label>.env.
+#
+# Install:  sudo cp scripts/comfyui-fp16.tmpfiles /etc/tmpfiles.d/comfyui-fp16.conf
+#           sudo systemd-tmpfiles --create /etc/tmpfiles.d/comfyui-fp16.conf
+d /run/comfyui-fp16 0775 brad brad -

--- a/scripts/comfyui-open.service
+++ b/scripts/comfyui-open.service
@@ -28,6 +28,11 @@ Environment=LLAMASWAP_URL=http://127.0.0.1:9090
 Environment=FREE_GPU_KEEP=chat,gemma-26b,small,small-uncensored
 Environment=FREE_GPU_IDLE_SECS=300
 Environment=FREE_GPU_RESTORE=coding
+# Optional per-instance extra args (currently only --fp16-unet), toggled from the
+# status page. Lives on tmpfs (/run) so it AUTO-RESETS to empty on every boot —
+# native fp16 never silently persists across a reboot. The leading '-' makes a
+# missing file non-fatal; COMFYUI_EXTRA_ARGS then expands to nothing.
+EnvironmentFile=-/run/comfyui-fp16/open.env
 # NO auth: acceptable because this port backs the MCP/Open WebUI (which has its
 # own auth) and is only reachable on the private LAN + Tailscale.
 # Shared: models/, custom_nodes/, --user-directory (workflows + settings).
@@ -39,7 +44,7 @@ ExecStart=/srv/ai/venvs/comfyui/bin/python /srv/ai/comfyui/main.py \
   --temp-directory /srv/ai/comfyui/temp-open \
   --user-directory /srv/ai/comfyui/user \
   --database-url sqlite:////srv/ai/comfyui/user/comfyui-open.db \
-  --preview-method auto
+  --preview-method auto $COMFYUI_EXTRA_ARGS
 Restart=on-failure
 RestartSec=3
 TimeoutStopSec=30

--- a/scripts/comfyui-secure.service
+++ b/scripts/comfyui-secure.service
@@ -28,6 +28,11 @@ Environment=LLAMASWAP_URL=http://127.0.0.1:9090
 Environment=FREE_GPU_KEEP=coding,gemma-31b,chat-uncensored-q4,chat-uncensored-q6,small,small-uncensored
 Environment=FREE_GPU_IDLE_SECS=300
 Environment=FREE_GPU_RESTORE=chat
+# Optional per-instance extra args (currently only --fp16-unet), toggled from the
+# status page. Lives on tmpfs (/run) so it AUTO-RESETS to empty on every boot —
+# native fp16 never silently persists across a reboot. The leading '-' makes a
+# missing file non-fatal; COMFYUI_EXTRA_ARGS then expands to nothing.
+EnvironmentFile=-/run/comfyui-fp16/secure.env
 # Auth: ComfyUI-Login is loaded via the extra custom_nodes path below (present
 # ONLY on this instance). Set the shared password on first visit to :8189/login.
 # The PASSWORD lives at /srv/ai/comfyui/login/PASSWORD (delete it to reset).
@@ -41,7 +46,7 @@ ExecStart=/srv/ai/venvs/comfyui/bin/python /srv/ai/comfyui/main.py \
   --temp-directory /srv/ai/comfyui/temp-secure \
   --user-directory /srv/ai/comfyui/user \
   --database-url sqlite:////srv/ai/comfyui/user/comfyui-secure.db \
-  --preview-method auto
+  --preview-method auto $COMFYUI_EXTRA_ARGS
 Restart=on-failure
 RestartSec=3
 TimeoutStopSec=30

--- a/scripts/server-status-service.py
+++ b/scripts/server-status-service.py
@@ -211,6 +211,16 @@ COMFYUI_UNIT_BY_LABEL = {
     (u[len("comfyui-"):] if u.startswith("comfyui-") else u): u
     for u in QUIET_COMFYUI_UNITS
 }
+# Per-instance native-fp16 toggle (--fp16-unet). Persisted as a tiny env file per
+# ComfyUI unit under a tmpfs runtime dir (see scripts/comfyui-fp16.tmpfiles) so it
+# AUTO-RESETS to off on every boot — no stale "enabled" survives a reboot. The
+# systemd unit reads it via EnvironmentFile=-/run/comfyui-fp16/<label>.env. The
+# dashboard lets you flip it ONLY while the instance is stopped, so the running
+# state always matches the checkbox. --fp16-unet affects EVERY model on that
+# instance (only MiniMax-H3 GGUF is validated: ~3.9x, and it needs the H3 fp16
+# fix node to avoid black frames), which is why it is off by default and per-run.
+COMFYUI_FP16_DIR = os.environ.get("COMFYUI_FP16_DIR", "/run/comfyui-fp16")
+COMFYUI_FP16_ARG = "--fp16-unet"
 # Optional creative-tool services (Fooocus/SwarmUI/InvokeAI) that are managed
 # on-demand: they are NOT enabled at boot (default off) and are started/stopped
 # from the dashboard via per-service buttons. Each holds VRAM on the V100s while
@@ -604,12 +614,13 @@ def collect_comfyui() -> list:
             port = None
         code, q = _http_status(f"{url}/queue")
         unit = COMFYUI_UNIT_BY_LABEL.get(label)
+        fp16 = _comfyui_fp16_state(unit)
         if code in (401, 403):
-            out.append({"label": label, "state": "locked", "port": port, "unit": unit})
+            out.append({"label": label, "state": "locked", "port": port, "unit": unit, "fp16": fp16})
             continue
         if code is None or q is None:
             out.append(
-                {"label": label, "state": "unreachable", "port": port, "unit": unit}
+                {"label": label, "state": "unreachable", "port": port, "unit": unit, "fp16": fp16}
             )
             continue
         running = len(q.get("queue_running") or [])
@@ -622,6 +633,7 @@ def collect_comfyui() -> list:
                 "pending": pending,
                 "port": port,
                 "unit": unit,
+                "fp16": fp16,
             }
         )
     return out
@@ -1253,6 +1265,61 @@ def _comfyui_ctl(action: str) -> tuple[bool, str]:
     return _systemctl_units(QUIET_COMFYUI_UNITS, action)
 
 
+def _comfyui_fp16_path(unit: str) -> str:
+    """Env-file path holding the per-unit --fp16-unet flag (comfyui-open ->
+    /run/comfyui-fp16/open.env)."""
+    label = unit[len("comfyui-"):] if unit.startswith("comfyui-") else unit
+    return os.path.join(COMFYUI_FP16_DIR, f"{label}.env")
+
+
+def _comfyui_fp16_state(unit: str) -> bool:
+    """True if the unit's native-fp16 flag file is present and enables --fp16-unet."""
+    if not unit:
+        return False
+    try:
+        with open(_comfyui_fp16_path(unit), encoding="utf-8") as f:
+            return COMFYUI_FP16_ARG in f.read()
+    except OSError:
+        return False
+
+
+def _set_comfyui_fp16(unit: str, enabled: bool) -> tuple[bool, str]:
+    """Write/clear the per-unit --fp16-unet env file. Refuses while the unit is
+    active — the flag must be chosen BEFORE start so the running instance always
+    matches what the checkbox shows. Returns (ok, detail)."""
+    if unit not in QUIET_COMFYUI_UNITS:
+        return False, f"unknown ComfyUI unit {unit!r}"
+    if _unit_is_active(unit):
+        return False, "stop the instance before changing native fp16"
+    path = _comfyui_fp16_path(unit)
+    try:
+        os.makedirs(COMFYUI_FP16_DIR, exist_ok=True)
+        if enabled:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(f"COMFYUI_EXTRA_ARGS={COMFYUI_FP16_ARG}\n")
+        else:
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+        return True, "on" if enabled else "off"
+    except OSError as exc:
+        return False, str(exc)
+
+
+def _reset_comfyui_fp16_all() -> None:
+    """Clear every unit's native-fp16 flag so the next start comes up in the
+    default, all-model-safe fp32 mode. Called at quiet-hours end (before the
+    auto-restart) so the nightly restore never silently re-enables fp16."""
+    for unit in QUIET_COMFYUI_UNITS:
+        try:
+            os.remove(_comfyui_fp16_path(unit))
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            print(f"[fp16] reset {unit} failed: {exc}")
+
+
 def _unit_is_active(unit: str) -> bool:
     """True if the systemd unit is active (no sudo needed for is-active)."""
     try:
@@ -1379,6 +1446,7 @@ def _enter_deep_idle() -> None:
 def _exit_window() -> None:
     print("[quiet] window ended — restoring active state")
     _QUIET_SUPPRESS_KEEPER.clear()
+    _reset_comfyui_fp16_all()
     _comfyui("start")
     for m in QUIET_WARM_ON_EXIT:
         _warm_model(m)
@@ -1469,6 +1537,10 @@ _HTML = """<!doctype html>
     padding:3px 10px; font-size:12px; cursor:pointer; margin-left:6px; font-family:inherit; }
   button.act:hover { background:#243247; }
   button.act:disabled { opacity:.5; cursor:default; }
+  label.fp16lbl { font-size:12px; color:#9fb0c7; margin-left:8px; cursor:pointer;
+    user-select:none; vertical-align:middle; }
+  label.fp16lbl input { vertical-align:middle; margin-right:3px; cursor:pointer; }
+  label.fp16lbl input:disabled { cursor:default; }
   .switch { position:relative; display:inline-block; width:42px; height:22px; vertical-align:middle; }
   .switch input { opacity:0; width:0; height:0; }
   .switch .slider { position:absolute; inset:0; cursor:pointer; background:#3a2a2a; border:1px solid #5a3a3a;
@@ -1734,6 +1806,17 @@ async function refresh(){  try{
         act = up
           ? `<button class="act" onclick="comfyAction('stop','${esc(c.unit)}')">⏹ Stop</button>`
           : `<button class="act" onclick="comfyAction('start','${esc(c.unit)}')">▶ Start</button>`;
+        // Native fp16 (--fp16-unet) toggle. Editable ONLY while the instance is
+        // stopped (a running instance already baked the flag into its args), so
+        // the checkbox always mirrors the live state. ~3.9× MiniMax-H3 on GGUF,
+        // but affects EVERY model on this instance — hence off by default.
+        const dis = up ? 'disabled' : '';
+        const ck = c.fp16 ? 'checked' : '';
+        const tt = up
+          ? 'stop this instance to change native fp16'
+          : 'native fp16 (--fp16-unet): ~3.9× MiniMax-H3 on GGUF, but affects ALL models on this instance';
+        act += ` <label class="fp16lbl" title="${tt}"><input type="checkbox" ${ck} ${dis}`
+          + ` onclick="comfyFp16('${esc(c.unit)}', this.checked)"> fp16</label>`;
       }
       return `<tr><td>ComfyUI <span class="sub">${esc(c.label)}</span></td><td>${state}</td><td>${linkHtml(null, c.port)}</td><td>${act}</td></tr>`;
     });
@@ -1806,6 +1889,21 @@ async function comfyAction(action, unit){
     if(msg) msg.textContent = d.ok ? ('ComfyUI '+label+' '+action+' ok') : ('failed: '+(d.detail||d.error||r.status));
   }catch(e){ if(msg) msg.textContent='error: '+e; }
   finally{ setTimeout(refresh, 1200); }
+}
+async function comfyFp16(unit, enabled){
+  const msg=document.getElementById('svcmsg');
+  document.querySelectorAll('#services input[type=checkbox]').forEach(b=>b.disabled=true);
+  const label = unit.replace('comfyui-','');
+  if(msg) msg.textContent = 'setting ComfyUI '+label+' native fp16 '+(enabled?'on':'off')+'…';
+  try{
+    const q='actions/comfyui-fp16?unit='+encodeURIComponent(unit)+'&enabled='+(enabled?'true':'false');
+    const r=await fetch(q,{method:'POST'});
+    const d=await r.json();
+    if(msg) msg.textContent = d.ok
+      ? ('ComfyUI '+label+' native fp16 '+(enabled?'on':'off'))
+      : ('failed: '+(d.detail||d.error||r.status));
+  }catch(e){ if(msg) msg.textContent='error: '+e; }
+  finally{ setTimeout(refresh, 900); }
 }
 async function serviceAction(name, action){
   const msg=document.getElementById('svcmsg');
@@ -1905,7 +2003,27 @@ class Handler(BaseHTTPRequestHandler):
                 "units": units, "detail": detail[:500],
             }).encode("utf-8")
             self._send(200 if ok else 500, body, "application/json")
-        elif path == "/actions/service":
+        elif path == "/actions/comfyui-fp16":
+            # Toggle a single ComfyUI instance's --fp16-unet flag. Only allowed
+            # while the instance is stopped (_set_comfyui_fp16 enforces this), so
+            # the checkbox always reflects the running state. Off by default and
+            # auto-cleared on boot (tmpfs) and at quiet-hours end.
+            if not STATUS_ACTIONS_ENABLED or not QUIET_COMFYUI_UNITS:
+                self._send(403, json.dumps(
+                    {"ok": False, "error": "comfyui actions disabled"}
+                ).encode("utf-8"), "application/json")
+                return
+            qs = urllib.parse.parse_qs(
+                self.path.split("?", 1)[1] if "?" in self.path else "")
+            unit = (qs.get("unit", [""])[0]).strip()
+            enabled = (qs.get("enabled", ["false"])[0]).lower() in (
+                "1", "true", "yes", "on")
+            ok, detail = _set_comfyui_fp16(unit, enabled)
+            _cache["at"] = 0.0  # force the next status poll to reflect the change
+            body = json.dumps({
+                "ok": ok, "unit": unit, "enabled": enabled, "detail": detail[:500],
+            }).encode("utf-8")
+            self._send(200 if ok else 400, body, "application/json")
             # Start/stop a managed creative-tool service (Fooocus/SwarmUI/InvokeAI).
             # Each unit has its own line in the server-status sudoers file.
             if not STATUS_ACTIONS_ENABLED or not MANAGED_SERVICES:


### PR DESCRIPTION
## What

Adds a per-ComfyUI-instance **fp16** (`--fp16-unet`) toggle to the status page so MiniMax-H3 can run at native fp16 on the V100s, plus README attribution for the ComfyUI custom nodes now in use.

## Why

On Volta (no bf16) ComfyUI silently falls back to **fp32** for H3, which is slow. Running the DiT on fp16 tensor cores is **~3.5× faster** — measured live on the secure slot: **38m32s → 10m53s** on a GGUF clip (`manual cast: torch.float32` → `manual cast: None`). But `--fp16-unet` is a per-instance flag affecting **every** model on that instance, so it must be opt-in per session.

## How it works

- **Checkbox** next to each ComfyUI Start/Stop button, **editable only while the instance is stopped** (once started, the flag is baked into the args and the checkbox locks to the live state).
- Flag stored as a tiny env file on **tmpfs** (`/run/comfyui-fp16/<label>.env`), read by the unit via `EnvironmentFile=-` + `$COMFYUI_EXTRA_ARGS`, so it **auto-resets to off on every reboot**. Quiet-hours end also clears it.
- Needs no new sudoers entry (status service writes `/run` as its own user); only start/stop use the existing scoped rule.

## Deploy (needs sudo)

\`\`\`bash
sudo cp scripts/comfyui-fp16.tmpfiles /etc/tmpfiles.d/comfyui-fp16.conf
sudo systemd-tmpfiles --create /etc/tmpfiles.d/comfyui-fp16.conf
sudo cp scripts/comfyui-open.service scripts/comfyui-secure.service /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl restart server-status
\`\`\`

## Notes

- The fp16 win requires a **non-int8** H3 model (GGUF or bf16); int8_convrot only gets ~1.28×.
- Depends on the `minimax_h3_fp16_fix.py` node (Amduraznak) to avoid black frames — attributed in the README along with MMAudio, H3-Multishot, MultiGPU, etc.
- Also adds `scripts/build-mmaudio-workflows.js` (the Wan+MMAudio workflow generator).

Docs: `docs/benchmarking.md` (bench + real-world), `docs/server-setup.md` (toggle runbook).