### PR TITLE
ComfyUI secure MCP bridge + UI-defaults workflow sync, status-page fixes, Titan X docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,14 +22,20 @@ Read this first, then the detailed docs:
 - **Agents cannot `sudo`.** Anything privileged (systemd install/restart, apt) must be
   handed to the user as a script/command they run. Non-privileged docker + llama-swap ops are fine.
 - **GPU ordering gotcha:** CUDA/llama.cpp/PyTorch order GPUs by *speed* by default
-  (V100s first, P100 last) — the OPPOSITE of `nvidia-smi`. **Always export
+  (V100s first, Titan X last) — the OPPOSITE of `nvidia-smi`. **Always export
   `CUDA_DEVICE_ORDER=PCI_BUS_ID`** for pinning/benchmarks. llama-swap model blocks already set it.
-- **Hardware:** i7-6950X, 128 GB RAM, 2 TB NVMe. GPUs: 2× Tesla V100-32GB (sm_70, idx1/idx2)
-  + 1× Tesla P100-16GB (sm_60, idx0), **no NVLink** (PCIe PHB). Ubuntu 24.04, driver 580, CUDA 12.x.
-- **CUDA 12.x only** — 13.x dropped Pascal/Volta (sm_60/sm_70). sm_70 also means **no fp8 /
+- **Hardware:** i7-6950X, 128 GB RAM, 2 TB NVMe. GPUs: 2× Tesla V100-PCIE-32GB (sm_70, idx1/idx2)
+  + 1× GTX Titan X (12 GB, Maxwell sm_52, idx0), **no NVLink** (PCIe PHB). Ubuntu 24.04, driver 580, CUDA 12.x.
+  - **idx0 is a stopgap:** the original Tesla P100-16GB (sm_60) died 2026-07-27 with an uncorrectable
+    HBM/ECC failure and was replaced by a spare 12 GB GTX Titan X (Maxwell sm_52). The Titan X can't run
+    sm_70 kernels and **crashes on the llama.cpp MTP `draft-mtp` path**, so all idx0 (`small*`) models run
+    dense Gemma-4-12B with the MTP draft stripped and reduced ctx (see `config/llama-swap.base.yaml`).
+    Restore the 26B MoE + draft + full ctx when a 16 GB+ card (P100/V100) returns to idx0.
+- **CUDA 12.x only** — 13.x dropped Maxwell/Pascal/Volta (sm_52/sm_60/sm_70). sm_70 also means **no fp8 /
   FlashAttention-2 / SageAttention**; use `sdpa` attention and avoid `*_fast` fp8 paths in ComfyUI.
 - **Keep GPUs under thermal limits** via power caps applied at boot by the `gpu-fan-control`
-  service (P100 200W, V100s 175W); V100 HBM throttles ~85 °C.
+  service (Titan X idx0 200W, V100 idx1 175W / idx2 200W); V100 HBM throttles ~85 °C. Maxwell GPU
+  Boost 2.0 self-trims the Titan X to ~200W/~1126MHz at its 83 °C target regardless of a higher cap.
 - **Clock is UTC, owner is US Eastern.** The machine runs `Etc/UTC` but the owner thinks in
   EST/EDT (~4–5 h offset). Any wall-clock scheduling (cron, timers, the quiet-hours window) must
   be timezone-aware — e.g. quiet-hours reads `QUIET_TZ=America/New_York`, not the system clock.
@@ -55,8 +61,9 @@ Read this first, then the detailed docs:
   `llama-swap-mode` MCP (`set_mode`). `list` / `current` / `show <mode>` to inspect.
 - **Model roster** (see `config/llama-swap.base.yaml` for exact args): `coding` (Qwen3.8-27B Q6_K
   **+ MTP** self-spec decode, 160k ctx, idx1), `chat` (Qwen3.6-35B-A3B MoE UD-Q6_K **+ MTP**, 96k
-  ctx, idx2), `big` (Qwen3.8-27B UD-Q8_K_XL **+ MTP**, dual-V100, 256k), `fast`
-  (Gemma-4-26B-A4B MoE, P100, non-reasoning), `gemma-31b`/`gemma-26b` (comparison), `chat-uncensored-q4/q6`.
+  ctx, idx2), `big` (Qwen3.8-27B UD-Q8_K_XL **+ MTP**, dual-V100, 256k), `small`/`fast`
+  (dense Gemma-4-12B QAT on the idx0 Titan X stopgap, non-reasoning, MTP disabled — was the
+  Gemma-4-26B-A4B MoE on the P100), `gemma-31b`/`gemma-26b` (comparison), `chat-uncensored-q4/q6`.
   Most Qwen3 models are **reasoning** models (thinking phase) — give generous `max_tokens`.
   The Qwen3.8 `coding`/`big` slots are pinned to `reasoning_effort=medium` in the base config
   (the template default `xhigh` balloons to 40k+ reasoning tokens on codegen and truncates).

--- a/docker/litellm/custom_hooks.py
+++ b/docker/litellm/custom_hooks.py
@@ -16,9 +16,52 @@ is harmless.
 This hook normalizes such messages by giving any content-less, tool_call-less
 assistant message an empty-string ``content`` (which llama-server accepts),
 making the stack resilient to one bad turn without the user losing context.
+
+disable_thinking_for_owui_tasks
+-------------------------------
+Open WebUI runs background "task" calls (chat title, tags, follow-up
+suggestions, retrieval/search query generation) against the *current chat
+model*. Our chat models are Qwen3 reasoning models, so each trivial task
+triggers a full multi-thousand-token thinking phase (~40-65s each). Chained
+after a message, several of these produce the long post-response "churn".
+
+Every Open WebUI auto-task prompt begins with the literal ``### Task:`` header
+(DEFAULT_{TITLE,TAGS,FOLLOW_UP,QUERY}_GENERATION_PROMPT_TEMPLATE all start with
+it). We detect that marker and inject ``chat_template_kwargs.enable_thinking =
+False`` so the task is answered directly, with no thinking phase. This keeps
+tasks on the user's chosen model (no task-model routing, no model swap) and
+preserves all Open WebUI features — it only removes the wasteful reasoning on
+these throwaway prompts. The kwarg is a harmless no-op for non-Qwen templates
+(Jinja ignores unused context variables).
 """
 
 from litellm.integrations.custom_logger import CustomLogger
+
+# Marker that prefixes every Open WebUI auto-task prompt template.
+_OWUI_TASK_MARKER = "### Task:"
+
+
+def _is_owui_task(messages):
+    """True if any message looks like an Open WebUI background task prompt."""
+    if not isinstance(messages, list):
+        return False
+    for m in messages:
+        if not isinstance(m, dict) or m.get("role") not in ("user", "system"):
+            continue
+        content = m.get("content")
+        if isinstance(content, str) and content.lstrip().startswith(_OWUI_TASK_MARKER):
+            return True
+        # Multimodal content: list of parts with {"type": "text", "text": ...}.
+        if isinstance(content, list):
+            for part in content:
+                if (
+                    isinstance(part, dict)
+                    and part.get("type") == "text"
+                    and isinstance(part.get("text"), str)
+                    and part["text"].lstrip().startswith(_OWUI_TASK_MARKER)
+                ):
+                    return True
+    return False
 
 
 class AIServerHooks(CustomLogger):
@@ -35,6 +78,15 @@ class AIServerHooks(CustomLogger):
                     ):
                         # Covers both a missing key and an explicit null.
                         m["content"] = ""
+
+            # Suppress the reasoning phase on Open WebUI background task calls.
+            if _is_owui_task(messages):
+                kwargs = data.get("chat_template_kwargs")
+                if not isinstance(kwargs, dict):
+                    kwargs = {}
+                # Don't override an explicit caller-provided value.
+                kwargs.setdefault("enable_thinking", False)
+                data["chat_template_kwargs"] = kwargs
         except Exception:
             # Never break a request from a sanitizer bug — fall through untouched.
             pass

--- a/docker/mcpo/config.json
+++ b/docker/mcpo/config.json
@@ -33,9 +33,14 @@
       }
     },
     "comfyui": {
-      "//": "Image/media generation via the (vendored) joenorton/comfyui-mcp-server, run natively as a streamable-http service (scripts/comfyui-mcp.service) on the host at :9000, talking to native ComfyUI at :8188. mcpo proxies it to Open WebUI + agents. Style workflows live in config/comfyui-mcp/workflows/. Tools: z_image_turbo (+ any style file), generate_image, run_workflow, get_job, view_image, list_assets, regenerate, cancel_job, etc.",
+      "//": "Image/media generation via the (vendored) joenorton/comfyui-mcp-server, run natively as a streamable-http service (scripts/comfyui-mcp.service) on the host at :9000, talking to native ComfyUI at :8188 (the OPEN instance). mcpo proxies it to Open WebUI + agents. Style workflows live in config/comfyui-mcp/workflows/. Tools: z_image_turbo (+ any style file), generate_image, run_workflow, get_job, view_image, list_assets, regenerate, cancel_job, etc.",
       "type": "streamable-http",
       "url": "http://host.docker.internal:9000/mcp"
+    },
+    "comfyui-secure": {
+      "//": "Same bridge as 'comfyui' but pointed at the login-gated SECURE ComfyUI (:8189, V100 idx2, ComfyUI-Login), served by scripts/comfyui-mcp-secure.service on the host at :9001. The bridge injects the ComfyUI-Login Bearer token (read from comfyui/login/PASSWORD) so its calls authenticate. Choose this tool namespace to send a workflow to the secure/private canvas instead of the open one. Identical tool set + shared style workflows.",
+      "type": "streamable-http",
+      "url": "http://host.docker.internal:9001/mcp"
     },
     "llama-swap-mode": {
       "//": "Switch the llama-swap SERVING MODE (daily / heavy-coding / ...) from a client. Runs NATIVELY on the host (scripts/llama-swap-mode-mcp.service, docker/mcpo/llama_swap_mode_mcp.py) at :9120 because it edits config/llama-swap.yaml + calls llama-swap :9090; mcpo proxies it here. Tools: list_modes, current_mode, show_mode, set_mode. Modes are overlays in config/modes/ applied over config/llama-swap.base.yaml by scripts/llama-swap-mode.py.",

--- a/scripts/comfyui-mcp-launch.py
+++ b/scripts/comfyui-mcp-launch.py
@@ -93,6 +93,115 @@ if _AUTH_TOKEN:
     print(f"[comfyui-mcp] Bearer auth enabled for ComfyUI at {sorted(_AUTH_HOSTPORTS)}",
           flush=True)
 
+# --------------------------------------------------------------------------- #
+# UI-defaults workflow patches (see scripts/comfyui_workflow_import.py).
+#
+# The bridge advertises a tool parameter for every PARAM_ placeholder an imported
+# workflow exposes, and at render time fills omitted params from the vendored
+# DefaultsManager's HARDCODED image defaults (width/height 512, steps 20) — NOT
+# from the values you set in the ComfyUI UI. That's why an omitted `steps` became
+# 20 instead of your workflow's 8. It also marks any placeholder outside a small
+# hardcoded set (e.g. input_image, megapixels, length) as *required*.
+#
+# These two class patches make imported workflows honor the UI:
+#   1. Relax `required` so ONLY `prompt` and `input_image` are mandatory; every
+#      other omitted knob falls back to the workflow's own captured UI value.
+#      Must run BEFORE `import server` because tool signatures (required vs
+#      optional) are frozen when the generation tools are registered at import.
+#   2. Wrap `render_workflow` to (a) merge the workflow's per-file `meta.json`
+#      `defaults` (the captured UI values) UNDER the caller-provided params so an
+#      omitted knob uses the UI value instead of the hardcoded 512/20, and (b)
+#      resolve `input_image`-kind params by uploading a URL / data-URI / bytes to
+#      ComfyUI's /upload/image and substituting the stored filename.
+# Toggle off with COMFY_MCP_UI_DEFAULTS=0.
+# --------------------------------------------------------------------------- #
+if os.getenv("COMFY_MCP_UI_DEFAULTS", "1").strip().lower() not in ("0", "false", "no", "off"):
+    import io as _io
+    import base64 as _base64
+    from managers import workflow_manager as _wm  # noqa: E402
+
+    _ALWAYS_REQUIRED = {"prompt", "input_image"}
+    _COMFY_URL = os.getenv("COMFYUI_URL", "http://127.0.0.1:8188").rstrip("/")
+
+    # --- (1) required-relax ------------------------------------------------- #
+    _orig_extract = _wm.WorkflowManager._extract_parameters
+
+    def _extract_parameters_relaxed(self, workflow):
+        params = _orig_extract(self, workflow)
+        for name, param in params.items():
+            param.required = name in _ALWAYS_REQUIRED
+        return params
+
+    _wm.WorkflowManager._extract_parameters = _extract_parameters_relaxed
+
+    # --- input_image upload helper ------------------------------------------ #
+    def _upload_input_image(value):
+        """Return a ComfyUI-input filename for a URL / data-URI / bare name."""
+        import requests  # local import; requests already patched for auth above
+        val = str(value).strip()
+        if not val:
+            return val
+        # A bare filename with no scheme/path is assumed to already live in the
+        # ComfyUI input dir (or a prior upload) -> pass through unchanged.
+        if "://" not in val and not val.startswith("data:") and "/" not in val:
+            return val
+        try:
+            if val.startswith("data:"):
+                _, _, b64 = val.partition(",")
+                raw = _base64.b64decode(b64)
+                fname = "mcp_input.png"
+            else:
+                r = requests.get(val, timeout=30)
+                r.raise_for_status()
+                raw = r.content
+                fname = os.path.basename(urlsplit(val).path) or "mcp_input.png"
+            files = {"image": (fname, _io.BytesIO(raw), "application/octet-stream")}
+            resp = requests.post(f"{_COMFY_URL}/upload/image", files=files,
+                                 data={"overwrite": "true", "type": "input"}, timeout=60)
+            resp.raise_for_status()
+            j = resp.json()
+            name = j.get("name", fname)
+            sub = j.get("subfolder", "")
+            return f"{sub}/{name}" if sub else name
+        except Exception as exc:  # noqa: BLE001 - surface a clear render error
+            print(f"[comfyui-mcp] input_image upload failed for {val!r}: {exc}",
+                  file=sys.stderr, flush=True)
+            return val
+
+    # --- (2) render_workflow: merge UI defaults + resolve input images ------- #
+    _orig_render = _wm.WorkflowManager.render_workflow
+
+    def _render_with_ui_defaults(self, definition, provided_params, defaults_manager=None):
+        merged = dict(provided_params or {})
+        try:
+            meta_path = self._safe_workflow_path(definition.workflow_id)
+            meta = self._load_workflow_metadata(meta_path) if meta_path else {}
+        except Exception:  # noqa: BLE001
+            meta = {}
+        ui_defaults = meta.get("defaults", {}) if isinstance(meta, dict) else {}
+        param_meta = meta.get("params", {}) if isinstance(meta, dict) else {}
+
+        # Fill omitted knobs from the workflow's captured UI values (seed stays
+        # unset so the vendored render randomizes it).
+        for name, param in definition.parameters.items():
+            if name == "seed":
+                continue
+            if merged.get(name) is None and name in ui_defaults:
+                merged[name] = ui_defaults[name]
+
+        # Resolve image-kind params (upload URL/data-URI -> input filename).
+        for name, info in param_meta.items():
+            if isinstance(info, dict) and info.get("kind") == "image":
+                if merged.get(name):
+                    merged[name] = _upload_input_image(merged[name])
+
+        return _orig_render(self, definition, merged, defaults_manager)
+
+    _wm.WorkflowManager.render_workflow = _render_with_ui_defaults
+    print("[comfyui-mcp] UI-defaults workflow patches active "
+          "(required=prompt/input_image only; omitted knobs use meta.json UI values)",
+          flush=True)
+
 # Upstream server.py runs a ComfyUI availability check at *import* time and calls
 # sys.exit(1) if ComfyUI is unreachable. That makes the bridge (and its :9000
 # endpoint) disappear whenever ComfyUI is intentionally down — e.g. the quiet-hours

--- a/scripts/comfyui-mcp-launch.py
+++ b/scripts/comfyui-mcp-launch.py
@@ -16,15 +16,72 @@ Config via env (see comfyui-mcp.service):
   COMFY_MCP_RETURN_MARKDOWN  when truthy, tools return a markdown image link for
                            inline display in mcpo/Open WebUI (not MCP ImageContent)
   COMFY_MCP_SRC            path to the upstream clone (default /srv/ai/src/comfyui-mcp-server)
+  COMFY_MCP_AUTH_TOKEN       Bearer token for a login-gated ComfyUI (ComfyUI-Login);
+                           injected into every request to the ComfyUI host.
+  COMFY_MCP_AUTH_TOKEN_FILE  path to a file whose FIRST LINE is that token (e.g. the
+                           secure instance's comfyui/login/PASSWORD). Preferred over
+                           COMFY_MCP_AUTH_TOKEN so the secret never lands in a unit
+                           file or env, and auto-tracks a password change. Ignored if
+                           COMFY_MCP_AUTH_TOKEN is set.
 """
 import os
 import sys
 import time
+from urllib.parse import urlsplit
 
 SRC = os.getenv("COMFY_MCP_SRC", "/srv/ai/src/comfyui-mcp-server")
 sys.path.insert(0, SRC)
 # publish-root detection uses cwd; run from the repo root like upstream expects.
 os.chdir(SRC)
+
+
+def _load_auth_token() -> str:
+    """Bearer token for a login-gated ComfyUI, from env or a file's first line."""
+    tok = os.getenv("COMFY_MCP_AUTH_TOKEN", "").strip()
+    if tok:
+        return tok
+    path = os.getenv("COMFY_MCP_AUTH_TOKEN_FILE", "").strip()
+    if path:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                return fh.readline().strip()
+        except OSError as exc:  # missing/unreadable -> run unauthenticated (degraded)
+            print(f"[comfyui-mcp] auth token file {path!r} unreadable: {exc}",
+                  file=sys.stderr, flush=True)
+    return ""
+
+
+# The (vendored) upstream talks to ComfyUI with module-level requests.get/post/head
+# calls (no shared Session, no auth header). A login-gated instance (ComfyUI-Login,
+# our :8189 "secure" canvas) rejects every unauthenticated call with 401/redirect.
+# Rather than fork upstream, wrap requests.Session.request to attach
+# `Authorization: Bearer <token>` for requests aimed at the ComfyUI host — including
+# the import-time availability probe (so the bridge starts NON-degraded on secure)
+# and the server-side asset HEAD/GET used to size/preview outputs. Installed BEFORE
+# `import server` for exactly that reason. No-op when no token is configured, so the
+# open (:8188, auth-less) bridge behaves exactly as before.
+_AUTH_TOKEN = _load_auth_token()
+if _AUTH_TOKEN:
+    import requests
+
+    _comfy = urlsplit(os.getenv("COMFYUI_URL", "http://127.0.0.1:8188"))
+    _COMFY_HOSTPORT = _comfy.netloc  # host:port we should authenticate to
+    _orig_request = requests.sessions.Session.request
+
+    def _request_with_auth(self, method, url, *args, **kwargs):
+        try:
+            same_host = urlsplit(url).netloc == _COMFY_HOSTPORT
+        except Exception:
+            same_host = False
+        if same_host:
+            headers = dict(kwargs.get("headers") or {})
+            headers.setdefault("Authorization", f"Bearer {_AUTH_TOKEN}")
+            kwargs["headers"] = headers
+        return _orig_request(self, method, url, *args, **kwargs)
+
+    requests.sessions.Session.request = _request_with_auth
+    print(f"[comfyui-mcp] Bearer auth enabled for ComfyUI at {_COMFY_HOSTPORT}",
+          flush=True)
 
 # Upstream server.py runs a ComfyUI availability check at *import* time and calls
 # sys.exit(1) if ComfyUI is unreachable. That makes the bridge (and its :9000

--- a/scripts/comfyui-mcp-launch.py
+++ b/scripts/comfyui-mcp-launch.py
@@ -64,13 +64,23 @@ _AUTH_TOKEN = _load_auth_token()
 if _AUTH_TOKEN:
     import requests
 
-    _comfy = urlsplit(os.getenv("COMFYUI_URL", "http://127.0.0.1:8188"))
-    _COMFY_HOSTPORT = _comfy.netloc  # host:port we should authenticate to
+    # Authenticate requests to EITHER the connection host (COMFYUI_URL, used for
+    # queueing + history polling) OR the public/display host (COMFY_MCP_PUBLIC_URL,
+    # used by the server-side asset HEAD/GET that sizes outputs and builds the inline
+    # preview). Both point at the same login-gated ComfyUI, just via different
+    # host:port (127.0.0.1:8189 vs 192.168.4.57:8189); without the public one those
+    # asset fetches 401 and the preview/metadata silently drops.
+    _AUTH_HOSTPORTS = set()
+    for _u in (os.getenv("COMFYUI_URL", "http://127.0.0.1:8188"),
+               os.getenv("COMFY_MCP_PUBLIC_URL", "")):
+        _u = (_u or "").strip()
+        if _u:
+            _AUTH_HOSTPORTS.add(urlsplit(_u).netloc)
     _orig_request = requests.sessions.Session.request
 
     def _request_with_auth(self, method, url, *args, **kwargs):
         try:
-            same_host = urlsplit(url).netloc == _COMFY_HOSTPORT
+            same_host = urlsplit(url).netloc in _AUTH_HOSTPORTS
         except Exception:
             same_host = False
         if same_host:
@@ -80,7 +90,7 @@ if _AUTH_TOKEN:
         return _orig_request(self, method, url, *args, **kwargs)
 
     requests.sessions.Session.request = _request_with_auth
-    print(f"[comfyui-mcp] Bearer auth enabled for ComfyUI at {_COMFY_HOSTPORT}",
+    print(f"[comfyui-mcp] Bearer auth enabled for ComfyUI at {sorted(_AUTH_HOSTPORTS)}",
           flush=True)
 
 # Upstream server.py runs a ComfyUI availability check at *import* time and calls
@@ -104,6 +114,30 @@ try:
     import server  # noqa: E402  (module-level ComfyUI availability check runs on import)
 finally:
     sys.exit, time.sleep = _orig_exit, _orig_sleep
+
+# Upstream blocks inline for at most max_attempts=30 (~30s) polling ComfyUI history;
+# on timeout it returns a "still running, use get_job(...)" handle. For a COLD render
+# on the secure canvas (14GB+ model load off disk + sampling) 30s is not enough, so
+# the tool hands back a job handle — and some models react by RE-QUEUEING the same
+# workflow instead of polling, producing duplicate GPU jobs and a long poll loop.
+# Extend the inline wait (COMFY_MCP_MAX_WAIT seconds, well under the client's ~300s
+# tool timeout) so typical cold renders finish in the first call. Only overrides the
+# upstream default of 30 (callers that pass an explicit value are left alone); no-op
+# if the env is unset, so the open bridge is unchanged unless configured.
+_max_wait = os.getenv("COMFY_MCP_MAX_WAIT", "").strip()
+if _max_wait:
+    import comfyui_client as _cc  # noqa: E402  (already imported via server)
+
+    _MAX_WAIT = int(_max_wait)
+    _orig_wait = _cc.ComfyUIClient._wait_for_prompt
+
+    def _wait_for_prompt_longer(self, prompt_id, max_attempts=30):
+        if max_attempts == 30:  # upstream default -> substitute our configured budget
+            max_attempts = _MAX_WAIT
+        return _orig_wait(self, prompt_id, max_attempts=max_attempts)
+
+    _cc.ComfyUIClient._wait_for_prompt = _wait_for_prompt_longer
+    print(f"[comfyui-mcp] inline wait extended to {_MAX_WAIT}s", flush=True)
 
 server.mcp.settings.host = os.getenv("FASTMCP_HOST", "0.0.0.0")
 _port = os.getenv("FASTMCP_PORT", "").strip()

--- a/scripts/comfyui-mcp-launch.py
+++ b/scripts/comfyui-mcp-launch.py
@@ -139,6 +139,38 @@ if _max_wait:
     _cc.ComfyUIClient._wait_for_prompt = _wait_for_prompt_longer
     print(f"[comfyui-mcp] inline wait extended to {_MAX_WAIT}s", flush=True)
 
+# When markdown mode is on (COMFY_MCP_RETURN_MARKDOWN), the tool result already
+# carries a browser-reachable markdown image link that Open WebUI renders inline.
+# Upstream ALSO exposes a `return_inline_preview` boolean tool parameter that, when
+# the model sets it True, embeds a ~16KB base64 data URI in the tool result. That
+# blob is redundant for display, poisons the conversation context, and — accumulated
+# across turns on a 35B model — balloons prompt-processing time into multi-minute,
+# no-token-output "churn" (and 10-min upstream timeouts). Force inline preview OFF so
+# only the compact markdown link is returned. `register_and_build_response` is
+# imported by-name into the tool modules, so patch each already-bound reference (and
+# the source) to override the flag. Set COMFY_MCP_KEEP_INLINE_PREVIEW=1 to opt out.
+_markdown_on = os.getenv("COMFY_MCP_RETURN_MARKDOWN", "").strip().lower() in (
+    "1", "true", "yes", "on")
+_keep_preview = os.getenv("COMFY_MCP_KEEP_INLINE_PREVIEW", "").strip().lower() in (
+    "1", "true", "yes", "on")
+if _markdown_on and not _keep_preview:
+    import tools.helpers as _helpers  # noqa: E402
+
+    _orig_build = _helpers.register_and_build_response
+
+    def _build_no_inline_preview(*args, **kwargs):
+        kwargs["return_inline_preview"] = False  # drop the base64 blob
+        return _orig_build(*args, **kwargs)
+
+    _helpers.register_and_build_response = _build_no_inline_preview
+    # Re-point the copies the tool modules imported at import time.
+    for _modname in ("tools.generation", "tools.workflow"):
+        _mod = sys.modules.get(_modname)
+        if _mod is not None and hasattr(_mod, "register_and_build_response"):
+            _mod.register_and_build_response = _build_no_inline_preview
+    print("[comfyui-mcp] inline base64 preview suppressed (markdown link only)",
+          flush=True)
+
 server.mcp.settings.host = os.getenv("FASTMCP_HOST", "0.0.0.0")
 _port = os.getenv("FASTMCP_PORT", "").strip()
 if _port:

--- a/scripts/comfyui-mcp-secure.service
+++ b/scripts/comfyui-mcp-secure.service
@@ -33,6 +33,11 @@ Environment=COMFY_MCP_PUBLIC_URL=http://192.168.4.57:8189
 # Return markdown image links (not MCP ImageContent) so Open WebUI via mcpo renders
 # generated images inline.
 Environment=COMFY_MCP_RETURN_MARKDOWN=1
+# Block inline up to this many seconds waiting for the render before returning a
+# "still running" job handle. Raised from the upstream 30s because the secure canvas
+# often serves heavier models with a cold 14GB+ load; without this the client
+# re-queues the same workflow (duplicate GPU jobs + a long poll loop).
+Environment=COMFY_MCP_MAX_WAIT=150
 # FastMCP's DNS-rebinding protection only trusts localhost by default; allow the
 # host:port pairs mcpo/agents use to reach THIS bridge (:9001).
 Environment=COMFY_MCP_ALLOWED_HOSTS=host.docker.internal:9001,127.0.0.1:9001,localhost:9001

--- a/scripts/comfyui-mcp-secure.service
+++ b/scripts/comfyui-mcp-secure.service
@@ -1,0 +1,54 @@
+[Unit]
+Description=ComfyUI MCP server (SECURE) — bridges the login-gated ComfyUI (:8189) to MCP clients (mcpo / agents)
+Documentation=https://github.com/joenorton/comfyui-mcp-server
+# Second instance of the bridge, pointed at the password-protected "secure" canvas
+# (comfyui-secure.service, V100 idx2, :8189, ComfyUI-Login). Lets Open WebUI/agents
+# target open vs secure by choosing the corresponding tool namespace (mcpo entries
+# "comfyui" -> :9000/open, "comfyui-secure" -> :9001/secure). Bridge only (no GPU).
+After=network-online.target comfyui-secure.service docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=brad
+Group=brad
+# Upstream clone (kept pristine for `git pull`); our launcher overrides bind host/port.
+WorkingDirectory=/srv/ai/src/comfyui-mcp-server
+# ComfyUI endpoint the bridge talks to — the SECURE instance on localhost.
+Environment=COMFYUI_URL=http://127.0.0.1:8189
+# Bearer token for the login gate is read at startup from the SECURE instance's
+# password file (first line == token). Keeping it a FILE means the secret never lands
+# in this unit or in git, and it auto-tracks a password change (scripts/reset-comfyui-password.sh).
+Environment=COMFY_MCP_AUTH_TOKEN_FILE=/srv/ai/comfyui/login/PASSWORD
+# Style workflow library — shared with the open bridge (tracked in the ai-server repo).
+Environment=COMFY_MCP_WORKFLOW_DIR=/srv/ai/config/comfyui-mcp/workflows
+# Bind on all interfaces so the mcpo container reaches us via host.docker.internal.
+Environment=FASTMCP_HOST=0.0.0.0
+# Distinct port from the open bridge (:9000). mcpo proxies this at the "comfyui-secure" entry.
+Environment=FASTMCP_PORT=9001
+# Browser-reachable ComfyUI URL used ONLY for display/asset links. Points at :8189;
+# the user's browser is authenticated to secure via its ComfyUI-Login cookie, so the
+# inline image links render without embedding the token in chat text.
+Environment=COMFY_MCP_PUBLIC_URL=http://192.168.4.57:8189
+# Return markdown image links (not MCP ImageContent) so Open WebUI via mcpo renders
+# generated images inline.
+Environment=COMFY_MCP_RETURN_MARKDOWN=1
+# FastMCP's DNS-rebinding protection only trusts localhost by default; allow the
+# host:port pairs mcpo/agents use to reach THIS bridge (:9001).
+Environment=COMFY_MCP_ALLOWED_HOSTS=host.docker.internal:9001,127.0.0.1:9001,localhost:9001
+# set_defaults / publish persistence goes under $HOME/.config/comfy-mcp.
+Environment=HOME=/home/brad
+ExecStart=/srv/ai/venvs/comfyui-mcp/bin/python /srv/ai/scripts/comfyui-mcp-launch.py
+# Bounce mcpo once THIS bridge is accepting connections so the comfyui-secure tools
+# always load (mcpo does not retry a backend that was down at its startup). Poll our
+# own port (:9001, any HTTP reply — a bare GET returns 406) for up to ~60s and ONLY
+# restart mcpo if the bridge came up (guards against a failed-restart loop when secure
+# ComfyUI is down). Leading '-' + guards: never fail this service on a missing tool.
+ExecStartPost=-/bin/bash -c 'for i in $(seq 1 30); do curl -s -o /dev/null http://127.0.0.1:9001/mcp && { sleep 2; docker restart mcpo 2>/dev/null || true; exit 0; }; sleep 2; done'
+Restart=on-failure
+RestartSec=3
+TimeoutStopSec=15
+KillMode=mixed
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/comfyui-mcp.service
+++ b/scripts/comfyui-mcp.service
@@ -28,6 +28,10 @@ Environment=COMFY_MCP_PUBLIC_URL=http://192.168.4.57:8188
 # Return markdown image links (not MCP ImageContent) so Open WebUI via mcpo renders
 # generated images inline — mcpo serializes ImageContent to inert data-URI text.
 Environment=COMFY_MCP_RETURN_MARKDOWN=1
+# Block inline up to this many seconds waiting for the render before returning a
+# "still running" job handle. Raised from the upstream 30s so a cold model load +
+# sampling finishes in the first call (avoids the client re-queueing duplicate jobs).
+Environment=COMFY_MCP_MAX_WAIT=150
 # set_defaults / publish persistence goes under $HOME/.config/comfy-mcp.
 Environment=HOME=/home/brad
 ExecStart=/srv/ai/venvs/comfyui-mcp/bin/python /srv/ai/scripts/comfyui-mcp-launch.py

--- a/scripts/comfyui_workflow_import.py
+++ b/scripts/comfyui_workflow_import.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python3
+"""Import any ComfyUI workflow into the MCP bridge's library, generically.
+
+Why this exists
+---------------
+ComfyUI's ``/prompt`` API only accepts *API-format* graphs
+(``{node_id: {class_type, inputs}}``). The bridge keeps its own pre-converted,
+parameterized copies in ``config/comfyui-mcp/workflows/`` — which drift from the
+workflow you actually tuned in the ComfyUI UI (wrong LoRA, stale steps, etc.).
+
+Rather than re-implement ComfyUI's fragile UI->API conversion, we reuse
+ComfyUI's *own* authoritative conversion: every image/video ComfyUI renders
+embeds the exact API graph it executed (PNG ``prompt`` tEXt chunk; mp4/webm
+``prompt`` metadata). Sub-graphs are already flattened in that embedded graph,
+so collapsed UI groups are a non-issue.
+
+Generic knob detection (the important part)
+-------------------------------------------
+Instead of assuming a ``KSampler`` topology, we scan **every** node for concrete
+(non-linked) inputs whose *name* matches a known knob (``seed``/``noise_seed``,
+``steps``, ``cfg``, ``sampler_name``, ``scheduler``, ``denoise``, ``width``,
+``height``, ``length``/``num_frames``, ``fps``/``frame_rate``, ``prompt``,
+``text``, ``image`` ...). ComfyUI input names are highly conventional across
+node classes, so this generalizes across t2i, img2img, upscale, edit and video
+(``SamplerCustomAdvanced`` chains, ``KSamplerAdvanced``, ``WanImageToVideo``,
+``MiniMaxH3ImageToVideo`` ...).
+
+Rules that keep it correct and general:
+  * A knob is only exposed (templatized) when every node it binds to holds the
+    **same** concrete value — otherwise it's left at the UI values (still
+    honored, just not chat-overridable) to avoid clobbering an asymmetric
+    two-stage sampler. Use a title tag to expose one specifically.
+  * **Title tags** are the authoritative escape hatch: rename a node in the UI
+    to include ``@steps`` / ``@seed`` / ``@width`` / ``@length`` / ``@fps`` /
+    ``@prompt`` / ``@negative`` / ``@input_image`` / ``@denoise`` (optionally
+    ``@steps:8`` to also pin the default). The tagged node's matching input is
+    bound to that param regardless of topology or value conflicts.
+  * The concrete UI value of every exposed knob is captured into the sidecar
+    ``<name>.meta.json`` ``defaults`` so an omitted param falls back to the UI
+    value (the launcher applies these at render time). ``prompt`` stays
+    required; ``seed`` is randomized on omit; ``input_image`` uploads on use.
+
+Usage
+-----
+    scripts/comfyui_workflow_import.py krea2_turbo_bf16 --from-output krea2-turbo-bf16
+    scripts/comfyui_workflow_import.py minimax_h3 --from-media .../MiniMax_H3_00006_.mp4
+    scripts/comfyui_workflow_import.py foo --from-api /path/exported_api.json --dry-run
+
+Changing which params are exposed changes the advertised tool schema, so after a
+first import (or a change to the exposed set) restart the bridges:
+    sudo systemctl restart comfyui-mcp comfyui-mcp-secure
+Content-only edits (LoRA/steps values) hot-reload with no restart.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import struct
+import sys
+import zlib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+DEFAULT_WORKFLOW_DIR = Path(
+    os.environ.get("COMFY_MCP_WORKFLOW_DIR", "/srv/ai/config/comfyui-mcp/workflows")
+)
+DEFAULT_OUTPUT_DIRS = [
+    Path("/srv/ai/comfyui/output-open"),
+    Path("/srv/ai/comfyui/output-secure"),
+    Path("/srv/ai/comfyui/output"),
+]
+
+# --------------------------------------------------------------------------- #
+# Knob catalog: param name -> (accepted input names, python type, placeholder).
+# Detection is by INPUT NAME across ALL node classes (not node class_type),
+# which is what makes this generic across sampler families and video nodes.
+# --------------------------------------------------------------------------- #
+KNOBS: dict[str, dict[str, Any]] = {
+    "seed":            {"names": ("seed", "noise_seed"),               "type": int,   "ph": "PARAM_INT_SEED"},
+    "steps":           {"names": ("steps",),                            "type": int,   "ph": "PARAM_INT_STEPS"},
+    "cfg":             {"names": ("cfg", "guidance", "cfg_scale"),      "type": float, "ph": "PARAM_FLOAT_CFG"},
+    "sampler_name":    {"names": ("sampler_name",),                     "type": str,   "ph": "PARAM_SAMPLER_NAME"},
+    "scheduler":       {"names": ("scheduler",),                        "type": str,   "ph": "PARAM_SCHEDULER"},
+    "denoise":         {"names": ("denoise",),                          "type": float, "ph": "PARAM_FLOAT_DENOISE"},
+    "width":           {"names": ("width",),                            "type": int,   "ph": "PARAM_INT_WIDTH"},
+    "height":          {"names": ("height",),                           "type": int,   "ph": "PARAM_INT_HEIGHT"},
+    "length":          {"names": ("length", "num_frames", "frames", "video_frames"),
+                                                                        "type": int,   "ph": "PARAM_INT_LENGTH"},
+    "fps":             {"names": ("fps", "frame_rate"),                 "type": float, "ph": "PARAM_FLOAT_FPS"},
+    "duration":        {"names": ("duration",),                         "type": float, "ph": "PARAM_FLOAT_DURATION"},
+    "megapixels":      {"names": ("megapixels", "total_megapixels"),    "type": float, "ph": "PARAM_FLOAT_MEGAPIXELS"},
+    "prompt":          {"names": ("prompt", "text", "positive"),        "type": str,   "ph": "PARAM_PROMPT"},
+    "negative_prompt": {"names": ("negative_prompt",),                  "type": str,   "ph": "PARAM_NEGATIVE_PROMPT"},
+    "input_image":     {"names": ("image",),                            "type": str,   "ph": "PARAM_INPUT_IMAGE", "kind": "image"},
+}
+# Knobs never auto-detected (only via an explicit title tag) because their input
+# name is too generic / ambiguous to grab safely.
+_TAG_ONLY = {"duration"}
+# Params that must always be supplied by the caller (no sensible UI default).
+REQUIRED_PARAMS = {"prompt", "input_image"}
+# Params excluded from captured defaults (handled specially at render time).
+_NO_DEFAULT = {"prompt", "seed", "input_image"}
+
+# Title-tag syntax:  @name   or   @name:default   (case-insensitive name).
+_TAG_RE = re.compile(r"@([a-zA-Z_][a-zA-Z0-9_]*)(?::([^\s@]+))?")
+# Friendly aliases accepted inside @tags.
+_TAG_ALIASES = {
+    "negative": "negative_prompt",
+    "neg": "negative_prompt",
+    "pos": "prompt",
+    "positive": "prompt",
+    "image": "input_image",
+    "img": "input_image",
+    "input": "input_image",
+    "sampler": "sampler_name",
+    "frames": "length",
+    "num_frames": "length",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Embedded-graph extraction (PNG tEXt/iTXt; mp4/webm/webp binary scan).
+# --------------------------------------------------------------------------- #
+def read_png_text_chunks(path: Path) -> dict[str, str]:
+    data = path.read_bytes()
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise ValueError(f"{path} is not a PNG file")
+    out: dict[str, str] = {}
+    pos = 8
+    while pos + 8 <= len(data):
+        (length,) = struct.unpack(">I", data[pos : pos + 4])
+        ctype = data[pos + 4 : pos + 8]
+        chunk = data[pos + 8 : pos + 8 + length]
+        pos += 12 + length
+        if ctype == b"tEXt":
+            key, _, val = chunk.partition(b"\x00")
+            out[key.decode("latin-1")] = val.decode("latin-1")
+        elif ctype == b"iTXt":
+            key, _, rest = chunk.partition(b"\x00")
+            if len(rest) < 2:
+                continue
+            comp_flag = rest[0]
+            body = rest[2:]
+            _, _, body = body.partition(b"\x00")
+            _, _, body = body.partition(b"\x00")
+            try:
+                text = zlib.decompress(body) if comp_flag == 1 else body
+                out[key.decode("latin-1")] = text.decode("utf-8")
+            except Exception:
+                pass
+        elif ctype == b"IEND":
+            break
+    return out
+
+
+def _balanced_json_after(data: bytes, key: bytes) -> Optional[str]:
+    """Find `key\\x00` (or `key=`) then return the first balanced {...} object."""
+    for sep in (key + b"\x00", key + b"="):
+        i = data.find(sep)
+        if i >= 0:
+            break
+    else:
+        return None
+    j = data.find(b"{", i)
+    if j < 0:
+        return None
+    depth = 0
+    in_str = False
+    esc = False
+    start = j
+    while j < len(data):
+        c = data[j]
+        if in_str:
+            if esc:
+                esc = False
+            elif c == 0x5C:  # backslash
+                esc = True
+            elif c == 0x22:  # quote
+                in_str = False
+        else:
+            if c == 0x22:
+                in_str = True
+            elif c == 0x7B:  # {
+                depth += 1
+            elif c == 0x7D:  # }
+                depth -= 1
+                if depth == 0:
+                    return data[start : j + 1].decode("utf-8", "replace")
+        j += 1
+    return None
+
+
+def api_graph_from_media(path: Path) -> dict:
+    """Extract the flattened API graph embedded by ComfyUI in a rendered file."""
+    suffix = path.suffix.lower()
+    if suffix == ".png":
+        chunks = read_png_text_chunks(path)
+        if "prompt" in chunks:
+            return json.loads(chunks["prompt"])
+        raise ValueError(f"{path}: no embedded 'prompt' graph (made by ComfyUI?)")
+    # mp4 / webm / webp / gif: ComfyUI writes the API graph as a 'prompt' tag.
+    data = path.read_bytes()
+    raw = _balanced_json_after(data, b"prompt")
+    if raw is None:
+        raise ValueError(f"{path}: no embedded 'prompt' graph found")
+    return json.loads(raw)
+
+
+def looks_like_api_graph(obj: Any) -> bool:
+    return isinstance(obj, dict) and any(
+        isinstance(v, dict) and "class_type" in v for v in obj.values()
+    )
+
+
+def load_source_graph(
+    name: str,
+    from_api: Optional[str] = None,
+    from_media: Optional[str] = None,
+    from_output: Optional[str] = None,
+    output_dirs: Optional[list[Path]] = None,
+) -> tuple[dict, str]:
+    if from_api:
+        p = Path(from_api)
+        obj = json.loads(p.read_text())
+        if not looks_like_api_graph(obj):
+            raise SystemExit(
+                f"{p} is not an API-format graph. In ComfyUI use "
+                "'Save (API Format)' / 'Export (API)', or import from a rendered "
+                "PNG/MP4 which embeds the API graph."
+            )
+        return obj, str(p)
+    if from_media:
+        p = Path(from_media)
+        return api_graph_from_media(p), str(p)
+    prefix = from_output or name.replace("_", "-")
+    p = newest_media_with_prefix(prefix, output_dirs or DEFAULT_OUTPUT_DIRS)
+    return api_graph_from_media(p), str(p)
+
+
+def newest_media_with_prefix(prefix: str, output_dirs: list[Path]) -> Path:
+    exts = ("png", "mp4", "webm", "webp", "gif")
+    candidates: list[Path] = []
+    for d in output_dirs:
+        if d.is_dir():
+            for ext in exts:
+                candidates.extend(d.rglob(f"{prefix}*.{ext}"))
+    if not candidates:
+        raise SystemExit(
+            f"No media matching '{prefix}*' under: "
+            + ", ".join(str(d) for d in output_dirs if d.is_dir())
+        )
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+# --------------------------------------------------------------------------- #
+# Graph helpers
+# --------------------------------------------------------------------------- #
+def _is_link(v: Any) -> bool:
+    return isinstance(v, list) and len(v) == 2 and isinstance(v[0], (str, int))
+
+
+def _concrete_inputs(node: dict) -> dict[str, Any]:
+    ins = node.get("inputs", {})
+    if not isinstance(ins, dict):
+        return {}
+    return {k: v for k, v in ins.items() if not _is_link(v)}
+
+
+def _title(node: dict) -> str:
+    return str(node.get("_meta", {}).get("title", "") or "")
+
+
+def _knob_for_input(input_name: str) -> Optional[str]:
+    for knob, spec in KNOBS.items():
+        if knob in _TAG_ONLY:
+            continue
+        if input_name in spec["names"]:
+            return knob
+    return None
+
+
+def _resolve_string_source(graph: dict, node_id: str, input_name: str):
+    """Follow a link one or two hops to the node holding the concrete string.
+
+    Handles prompt text sourced from Primitive/Text nodes feeding CLIPTextEncode.
+    Returns (node_id, input_name) of the concrete string widget, or None.
+    """
+    node = graph.get(node_id)
+    if not isinstance(node, dict):
+        return None
+    val = node.get("inputs", {}).get(input_name)
+    if isinstance(val, str):
+        return (node_id, input_name)
+    if not _is_link(val):
+        return None
+    src_id = str(val[0])
+    src = graph.get(src_id)
+    if not isinstance(src, dict):
+        return None
+    # First concrete string input on the source node (Primitive 'value', Text, ...)
+    for k, v in _concrete_inputs(src).items():
+        if isinstance(v, str) and v.strip():
+            return (src_id, k)
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Templatize
+# --------------------------------------------------------------------------- #
+def _classify_text_encodes(graph: dict) -> dict[str, str]:
+    """Map CLIPTextEncode-ish node_id -> 'prompt' | 'negative_prompt' by title."""
+    roles: dict[str, str] = {}
+    for nid, node in graph.items():
+        if not isinstance(node, dict):
+            continue
+        ct = str(node.get("class_type", ""))
+        if "TextEncode" not in ct and "CLIPTextEncode" not in ct:
+            continue
+        if "text" not in node.get("inputs", {}):
+            continue
+        title = _title(node).lower()
+        if "negativ" in title:
+            roles[nid] = "negative_prompt"
+        elif "positiv" in title:
+            roles[nid] = "prompt"
+        else:
+            roles[nid] = "prompt"  # default assume positive
+    return roles
+
+
+def _scan_title_tags(graph: dict) -> dict[str, list[tuple[str, str, Any]]]:
+    """param -> list of (node_id, input_name, pinned_default_or_None) from @tags."""
+    tagged: dict[str, list[tuple[str, str, Any]]] = {}
+    for nid, node in graph.items():
+        if not isinstance(node, dict):
+            continue
+        for m in _TAG_RE.finditer(_title(node)):
+            raw = m.group(1).lower()
+            param = _TAG_ALIASES.get(raw, raw)
+            if param not in KNOBS:
+                continue
+            pinned = m.group(2)
+            # Locate the matching input on this node.
+            target = _tag_target_input(graph, nid, node, param)
+            if target is None:
+                continue
+            t_nid, t_in = target
+            tagged.setdefault(param, []).append((t_nid, t_in, pinned))
+    return tagged
+
+
+def _tag_target_input(graph, nid, node, param):
+    spec = KNOBS[param]
+    ins = node.get("inputs", {})
+    # Prompt/negative may be a link to a text/primitive source.
+    if param in ("prompt", "negative_prompt"):
+        for cand in ("text", "prompt", "positive"):
+            if cand in ins:
+                r = _resolve_string_source(graph, nid, cand)
+                if r:
+                    return r
+        # else fall through to name match
+    for cand in spec["names"]:
+        if cand in ins and not _is_link(ins[cand]):
+            return (nid, cand)
+    # Single concrete widget fallback (e.g. Primitive value).
+    concrete = _concrete_inputs(node)
+    if len(concrete) == 1:
+        return (nid, next(iter(concrete)))
+    return None
+
+
+def templatize(graph: dict) -> tuple[dict, dict]:
+    """Return (templatized_graph, meta). meta has defaults/params/report."""
+    graph = json.loads(json.dumps(graph))  # deep copy
+    text_roles = _classify_text_encodes(graph)
+    tags = _scan_title_tags(graph)
+
+    # Gather auto candidates: param -> list of (node_id, input_name, value)
+    candidates: dict[str, list[tuple[str, str, Any]]] = {}
+
+    def add_candidate(param, nid, inp, val):
+        candidates.setdefault(param, []).append((nid, inp, val))
+
+    for nid, node in graph.items():
+        if not isinstance(node, dict):
+            continue
+        for inp, val in _concrete_inputs(node).items():
+            # Prompt/negative handled via text-encode roles + name below.
+            if inp in ("text",):
+                role = text_roles.get(nid)
+                if role and isinstance(val, str):
+                    add_candidate(role, nid, inp, val)
+                continue
+            knob = _knob_for_input(inp)
+            if not knob:
+                continue
+            if knob == "prompt" and inp == "positive":
+                continue  # 'positive' is usually a link; skip stray matches
+            # Type sanity: don't grab a string where we expect a number, etc.
+            if not _value_type_ok(knob, val):
+                continue
+            add_candidate(knob, nid, inp, val)
+
+    # Also catch prompt text sourced through a link on positive text-encodes.
+    for nid, role in text_roles.items():
+        if any(c[0] == nid for c in candidates.get(role, [])):
+            continue
+        r = _resolve_string_source(graph, nid, "text")
+        if r:
+            src_id, src_in = r
+            val = graph[src_id]["inputs"][src_in]
+            add_candidate(role, src_id, src_in, val)
+
+    params: dict[str, dict] = {}
+    defaults: dict[str, Any] = {}
+    exposed: dict[str, dict] = {}
+    skipped: dict[str, str] = {}
+
+    all_params = set(candidates) | set(tags)
+    for param in all_params:
+        spec = KNOBS[param]
+        tag_binds = tags.get(param, [])
+        if tag_binds:
+            bindings = [(n, i) for (n, i, _p) in tag_binds]
+            pinned = next((p for (_n, _i, p) in tag_binds if p is not None), None)
+            if pinned is not None:
+                value = _coerce(pinned, spec["type"])
+            else:
+                # take value from first tagged binding's current graph value
+                n0, i0 = bindings[0]
+                value = graph[n0]["inputs"].get(i0)
+            source = "tag"
+        else:
+            binds = candidates.get(param, [])
+            values = [v for (_n, _i, v) in binds]
+            bindings = [(n, i) for (n, i, _v) in binds]
+            # Equal-value gate: only expose if all bound values agree.
+            if len({json.dumps(v, sort_keys=True) for v in values}) > 1:
+                skipped[param] = (
+                    f"differing values across {len(bindings)} nodes "
+                    f"({values!r}); tag one node with @{param} to expose"
+                )
+                continue
+            value = values[0]
+            source = "auto"
+
+        # Inject placeholder at every binding.
+        for (n, i) in bindings:
+            if n in graph and "inputs" in graph[n]:
+                graph[n]["inputs"][i] = spec["ph"]
+        params[param] = {
+            "type": spec["type"].__name__,
+            "kind": spec.get("kind", "scalar"),
+            "bindings": [list(b) for b in bindings],
+            "source": source,
+        }
+        exposed[param] = {"value": value, "source": source, "bindings": bindings}
+        if param not in _NO_DEFAULT and value is not None:
+            defaults[param] = _coerce(value, spec["type"])
+
+    meta = {
+        "params": params,
+        "defaults": defaults,
+        "report": {
+            "exposed": {k: {"value": v["value"], "source": v["source"],
+                            "bindings": [list(b) for b in v["bindings"]]}
+                        for k, v in exposed.items()},
+            "skipped": skipped,
+        },
+    }
+    return graph, meta
+
+
+def _value_type_ok(knob: str, val: Any) -> bool:
+    t = KNOBS[knob]["type"]
+    if knob in ("prompt", "negative_prompt", "sampler_name", "scheduler", "input_image"):
+        return isinstance(val, str)
+    if t is int:
+        return isinstance(val, bool) is False and isinstance(val, (int,)) and not isinstance(val, bool)
+    if t is float:
+        return isinstance(val, (int, float)) and not isinstance(val, bool)
+    return True
+
+
+def _coerce(val: Any, t: type):
+    try:
+        if t is int:
+            return int(float(val)) if isinstance(val, str) else int(val)
+        if t is float:
+            return float(val)
+        if t is str:
+            return str(val)
+        if t is bool:
+            if isinstance(val, str):
+                return val.strip().lower() in ("1", "true", "yes", "on")
+            return bool(val)
+    except (ValueError, TypeError):
+        return val
+    return val
+
+
+# --------------------------------------------------------------------------- #
+# Meta assembly + write
+# --------------------------------------------------------------------------- #
+def build_meta(name: str, source: str, meta_core: dict, prior: dict) -> dict:
+    params = meta_core["params"]
+    override_mappings = {p: [tuple(b) for b in info["bindings"]]
+                         for p, info in params.items()}
+    graph_hash = None  # filled by caller after templatized graph is serialized
+    meta = dict(prior)  # preserve any user-added name/description/constraints
+    meta.setdefault("name", name.replace("_", " ").title())
+    meta.setdefault("description", f"Execute the '{name}' ComfyUI workflow.")
+    meta["defaults"] = meta_core["defaults"]
+    meta["params"] = params
+    meta["override_mappings"] = {k: [list(b) for b in v]
+                                 for k, v in override_mappings.items()}
+    meta["required"] = sorted(p for p in params if p in REQUIRED_PARAMS)
+    meta["source"] = source
+    meta["updated_at"] = datetime.now(timezone.utc).isoformat()
+    meta["report"] = meta_core["report"]
+    return meta
+
+
+def import_workflow(
+    name: str,
+    graph: dict,
+    source: str,
+    dest_dir: Path = DEFAULT_WORKFLOW_DIR,
+    dry_run: bool = False,
+) -> dict:
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", name)
+    templ, core = templatize(graph)
+    templ_json = json.dumps(templ, indent=2, sort_keys=True)
+
+    wf_path = dest_dir / f"{safe}.json"
+    meta_path = dest_dir / f"{safe}.meta.json"
+    prior = {}
+    if meta_path.exists():
+        try:
+            prior = json.loads(meta_path.read_text())
+        except json.JSONDecodeError:
+            prior = {}
+    meta = build_meta(safe, source, core, prior)
+    meta["hash"] = hashlib.sha256(templ_json.encode()).hexdigest()[:16]
+    meta_json = json.dumps(meta, indent=2, sort_keys=True)
+
+    # Detect schema (exposed-param-set) change -> needs bridge restart.
+    prior_params = set((prior or {}).get("params", {}).keys())
+    new_params = set(meta["params"].keys())
+    schema_changed = prior_params != new_params
+    old_hash = (prior or {}).get("hash")
+    changed = old_hash != meta["hash"] or not wf_path.exists()
+
+    result = {
+        "name": safe,
+        "source": source,
+        "workflow_path": str(wf_path),
+        "meta_path": str(meta_path),
+        "exposed": meta["report"]["exposed"],
+        "skipped": meta["report"]["skipped"],
+        "defaults": meta["defaults"],
+        "required": meta["required"],
+        "schema_changed": schema_changed,
+        "prior_params": sorted(prior_params),
+        "new_params": sorted(new_params),
+        "content_changed": changed,
+        "restart_needed": schema_changed,
+        "dry_run": dry_run,
+    }
+    if not dry_run:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        wf_path.write_text(templ_json + "\n")
+        meta_path.write_text(meta_json + "\n")
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _fmt_report(r: dict) -> str:
+    lines = []
+    lines.append(f"workflow : {r['name']}")
+    lines.append(f"source   : {r['source']}")
+    lines.append("exposed  :")
+    for p, info in sorted(r["exposed"].items()):
+        binds = ", ".join(f"{n}.{i}" for n, i in info["bindings"])
+        lines.append(f"    {p:16} = {info['value']!r:40.40}  [{info['source']}]  ({binds})")
+    if r["skipped"]:
+        lines.append("skipped  :")
+        for p, why in sorted(r["skipped"].items()):
+            lines.append(f"    {p:16} : {why}")
+    lines.append(f"required : {r['required']}")
+    lines.append(f"defaults : {json.dumps(r['defaults'])}")
+    if r["schema_changed"]:
+        lines.append(
+            f"restart  : YES — exposed set changed {r['prior_params']} -> {r['new_params']}\n"
+            "           sudo systemctl restart comfyui-mcp comfyui-mcp-secure"
+        )
+    else:
+        lines.append("restart  : no (content hot-reloads by mtime)")
+    if r["dry_run"]:
+        lines.append("(dry-run: nothing written)")
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("name", help="bridge workflow id (file stem) to write")
+    src = ap.add_mutually_exclusive_group()
+    src.add_argument("--from-media", help="a rendered PNG/MP4/WEBM embedding the API graph")
+    src.add_argument("--from-api", help="an API-format JSON (ComfyUI Save/Export API)")
+    src.add_argument("--from-output", help="SaveImage/SaveVideo filename prefix to find newest render")
+    ap.add_argument("--output-dir", action="append", type=Path,
+                    help="extra ComfyUI output dir to scan (repeatable)")
+    ap.add_argument("--dest-dir", type=Path, default=DEFAULT_WORKFLOW_DIR,
+                    help=f"bridge workflow dir (default {DEFAULT_WORKFLOW_DIR})")
+    ap.add_argument("--dry-run", action="store_true", help="analyze only, write nothing")
+    ap.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = ap.parse_args(argv)
+
+    graph, source = load_source_graph(
+        args.name,
+        from_api=args.from_api,
+        from_media=args.from_media,
+        from_output=args.from_output,
+        output_dirs=args.output_dir or DEFAULT_OUTPUT_DIRS,
+    )
+    result = import_workflow(args.name, graph, source,
+                             dest_dir=args.dest_dir, dry_run=args.dry_run)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(_fmt_report(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install-comfyui-mcp-service.sh
+++ b/scripts/install-comfyui-mcp-service.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
-# Install the ComfyUI MCP server systemd service (image-gen tools for mcpo/agents).
+# Install the ComfyUI MCP server systemd service(s) (image-gen tools for mcpo/agents).
 #
-# This is a CPU-only bridge that exposes the (vendored) joenorton/comfyui-mcp-server
-# over streamable-http on 0.0.0.0:9000, talking to native ComfyUI at 127.0.0.1:8188.
-# mcpo proxies it to Open WebUI + agents (docker/mcpo/config.json).
+# Two CPU-only bridges run the (vendored) joenorton/comfyui-mcp-server over
+# streamable-http, one per ComfyUI instance:
+#   comfyui-mcp.service         -> 0.0.0.0:9000 -> native ComfyUI :8188 (OPEN)
+#   comfyui-mcp-secure.service  -> 0.0.0.0:9001 -> native ComfyUI :8189 (SECURE, login-gated)
+# mcpo proxies both to Open WebUI + agents (docker/mcpo/config.json: comfyui / comfyui-secure).
 #
 # Prereqs:
 #   - upstream clone at /srv/ai/src/comfyui-mcp-server (git clone at e0101b2, then
 #     `git am /srv/ai/scripts/patches/comfyui-mcp-server-local.patch` for the local fixes)
 #   - venv at /srv/ai/venvs/comfyui-mcp with requirements.txt + mcp[cli] installed
 #   - style workflows in /srv/ai/config/comfyui-mcp/workflows/
+#   - secure bridge only: /srv/ai/comfyui/login/PASSWORD exists (ComfyUI-Login token)
 #
 # RUN WITH SUDO:  sudo /srv/ai/scripts/install-comfyui-mcp-service.sh
 set -euo pipefail
@@ -20,7 +23,6 @@ PY=/srv/ai/venvs/comfyui-mcp/bin/python
 LAUNCH=/srv/ai/scripts/comfyui-mcp-launch.py
 CLONE=/srv/ai/src/comfyui-mcp-server
 WFDIR=/srv/ai/config/comfyui-mcp/workflows
-UNIT=/etc/systemd/system/comfyui-mcp.service
 
 # sanity checks
 [[ -x "$PY" ]]      || { echo "comfyui-mcp venv python missing at $PY"; exit 1; }
@@ -28,25 +30,35 @@ UNIT=/etc/systemd/system/comfyui-mcp.service
 [[ -f "$CLONE/server.py" ]] || { echo "upstream clone missing at $CLONE"; exit 1; }
 [[ -d "$WFDIR" ]]   || { echo "workflow dir missing at $WFDIR"; exit 1; }
 
-install -m644 "$SRC/comfyui-mcp.service" "$UNIT"
+# Install both units: open (:9000) and secure (:9001).
+for svc in comfyui-mcp comfyui-mcp-secure; do
+  install -m644 "$SRC/$svc.service" "/etc/systemd/system/$svc.service"
+done
 systemctl daemon-reload
-# Bridge is cheap (no GPU) and useful whenever ComfyUI is up — enable at boot.
-systemctl enable comfyui-mcp.service
-systemctl restart comfyui-mcp.service
+# Bridges are cheap (no GPU) and useful whenever ComfyUI is up — enable at boot.
+for svc in comfyui-mcp comfyui-mcp-secure; do
+  systemctl enable "$svc.service"
+  systemctl restart "$svc.service"
+done
 
 sleep 4
-systemctl --no-pager --full status comfyui-mcp.service | head -12
+for svc in comfyui-mcp comfyui-mcp-secure; do
+  systemctl --no-pager --full status "$svc.service" | head -12
+  echo
+done
 
 # mcpo does not retry backends that were down at its startup, so bounce it now that
-# the :9000 service is up to (re)establish the 'comfyui' connection. Run as the repo
-# owner so it uses brad's docker/compose context.
+# the :9000/:9001 services are up to (re)establish the 'comfyui'/'comfyui-secure'
+# connections. Run as the repo owner so it uses brad's docker/compose context.
 if command -v docker >/dev/null 2>&1; then
   sudo -u brad sh -lc 'cd /srv/ai/docker && docker compose restart mcpo' || \
     echo "NOTE: could not restart mcpo automatically — run: cd /srv/ai/docker && docker compose restart mcpo"
 fi
 
 echo
-echo "ComfyUI MCP server on http://<host>:9000/mcp (streamable-http, NO auth — LAN/Tailscale only)."
-echo "Logs:    journalctl -u comfyui-mcp -f"
-echo "Restart: sudo systemctl restart comfyui-mcp"
-echo "mcpo:    exposed to Open WebUI/agents via docker/mcpo/config.json (comfyui entry)."
+echo "ComfyUI MCP bridges (streamable-http, NO auth on the bridge — LAN/Tailscale only):"
+echo "  open   -> http://<host>:9000/mcp  (ComfyUI :8188)"
+echo "  secure -> http://<host>:9001/mcp  (ComfyUI :8189, login-gated; bridge injects the token)"
+echo "Logs:    journalctl -u comfyui-mcp -f   |   journalctl -u comfyui-mcp-secure -f"
+echo "Restart: sudo systemctl restart comfyui-mcp comfyui-mcp-secure"
+echo "mcpo:    exposed to Open WebUI/agents via docker/mcpo/config.json (comfyui / comfyui-secure entries)."

--- a/scripts/server-status-service.py
+++ b/scripts/server-status-service.py
@@ -40,6 +40,7 @@ import math
 import os
 import re
 import subprocess
+import sys
 import threading
 import time
 import urllib.error
@@ -48,6 +49,7 @@ import urllib.request
 import datetime as dt
 from collections import deque
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 
 HOST = os.environ.get("STATUS_HOST", "0.0.0.0")
 PORT = int(os.environ.get("STATUS_PORT", "9095"))
@@ -255,6 +257,20 @@ STATUS_ACTIONS_ENABLED = os.environ.get("STATUS_ACTIONS_ENABLED", "true").lower(
     "1",
     "true",
     "yes",
+)
+# Let the dashboard re-import a ComfyUI workflow into the MCP bridge's library from
+# the latest render (scripts/comfyui_workflow_import.py). This templatizes the
+# workflow's knobs to PARAM_ placeholders and captures the UI values as meta.json
+# defaults so chat picks up whatever you set in the ComfyUI UI. Runs as this
+# service's own user (no sudo); a bridge RESTART is only needed when the exposed
+# param SET changes (reported back in the response).
+WORKFLOW_SYNC_ENABLED = os.environ.get("WORKFLOW_SYNC_ENABLED", "true").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+COMFY_MCP_WORKFLOW_DIR = os.environ.get(
+    "COMFY_MCP_WORKFLOW_DIR", "/srv/ai/config/comfyui-mcp/workflows"
 )
 # Allow the dashboard to adjust per-GPU sustained power caps. The chosen watts are
 # written into the gpu-fan-control config, which the daemon treats as the live
@@ -599,6 +615,82 @@ def collect_models() -> dict:
             "mode": cfg["mode"], "config": cfg["models"]}
 
 
+def collect_workflows() -> list:
+    """List the MCP bridge's workflow library (COMFY_MCP_WORKFLOW_DIR).
+
+    Each entry summarizes what chat can control for that workflow, read from the
+    sidecar <name>.meta.json written by scripts/comfyui_workflow_import.py:
+    {id, name, exposed (param names), required, defaults, updated_at, has_meta,
+     source_prefix}. source_prefix is the SaveImage/SaveVideo filename prefix the
+     one-click sync scans for the newest render (name with '_' -> '-').
+    """
+    out: list = []
+    wf_dir = Path(COMFY_MCP_WORKFLOW_DIR)
+    if not wf_dir.is_dir():
+        return out
+    for wf_path in sorted(wf_dir.glob("*.json")):
+        if wf_path.name.endswith(".meta.json"):
+            continue
+        wid = wf_path.stem
+        meta_path = wf_path.with_suffix(".meta.json")
+        meta = {}
+        if meta_path.exists():
+            try:
+                meta = json.loads(meta_path.read_text())
+            except (json.JSONDecodeError, OSError):
+                meta = {}
+        params = meta.get("params", {}) if isinstance(meta, dict) else {}
+        out.append({
+            "id": wid,
+            "name": meta.get("name", wid.replace("_", " ").title()),
+            "exposed": sorted(params.keys()),
+            "required": meta.get("required", []),
+            "defaults": meta.get("defaults", {}),
+            "updated_at": meta.get("updated_at"),
+            "has_meta": bool(meta),
+            "source_prefix": wid.replace("_", "-"),
+        })
+    return out
+
+
+def _sync_workflow(name: str, source: str = "", dry_run: bool = False) -> tuple[bool, dict]:
+    """Import/refresh one bridge workflow from a render (see comfyui_workflow_import).
+
+    `source` may be empty (newest render matching the workflow's prefix), a media
+    path (PNG/MP4/WEBM embedding the API graph), or a SaveImage/SaveVideo prefix.
+    Returns (ok, report). Runs in-process as this service's user; never sudo.
+    """
+    try:
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        import comfyui_workflow_import as cwi  # noqa: WPS433 (lazy, stdlib-only)
+    except Exception as exc:  # noqa: BLE001
+        return False, {"error": f"import engine unavailable: {exc}"}
+
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", (name or "").strip())
+    if not safe:
+        return False, {"error": "missing workflow name"}
+    src = (source or "").strip()
+    kwargs = {}
+    media_exts = (".png", ".mp4", ".webm", ".webp", ".gif")
+    if not src:
+        kwargs["from_output"] = None  # engine defaults to name's '-' prefix
+    elif "/" in src or src.lower().endswith(media_exts):
+        kwargs["from_media"] = src
+    else:
+        kwargs["from_output"] = src
+    try:
+        graph, resolved = cwi.load_source_graph(safe, **kwargs)
+        report = cwi.import_workflow(
+            safe, graph, resolved,
+            dest_dir=Path(COMFY_MCP_WORKFLOW_DIR), dry_run=dry_run,
+        )
+        return True, report
+    except SystemExit as exc:  # engine raises SystemExit for user-facing errors
+        return False, {"error": str(exc)}
+    except Exception as exc:  # noqa: BLE001
+        return False, {"error": f"{type(exc).__name__}: {exc}"}
+
+
 def collect_comfyui() -> list:
     out = []
     for pair in COMFYUI_URLS.split(","):
@@ -916,6 +1008,7 @@ def build_status() -> dict:
         "gpus": gpus,
         "host": host,
         "power_mode": _power_state["mode"],
+        "workflows": collect_workflows() if WORKFLOW_SYNC_ENABLED else [],
         "quiet": {
             "enabled": QUIET_HOURS_ENABLED,
             "paused": _QUIET_PAUSED.is_set(),
@@ -938,6 +1031,7 @@ def build_status() -> dict:
             "quiet": STATUS_ACTIONS_ENABLED and QUIET_HOURS_ENABLED,
             "gpu_power": GPU_POWER_ACTIONS_ENABLED,
             "gpu_power_range": [GPU_POWER_MIN_W, GPU_POWER_MAX_W, GPU_POWER_STEP_W],
+            "workflow_sync": STATUS_ACTIONS_ENABLED and WORKFLOW_SYNC_ENABLED,
         },
     }
 
@@ -1572,6 +1666,10 @@ _HTML = """<!doctype html>
   <section><h2>History <span class="hsub" id="histspan"></span></h2><div id="history">…</div></section>
   <section><h2>Host (CPU / RAM / Disk)</h2><div id="host">…</div></section>
   <section><h2>Services <span class="hsub" id="svcactions"></span></h2><div id="services">…</div></section>
+  <section id="wfsyncsec" style="display:none"><h2>ComfyUI workflow sync <span class="hsub" id="wfsyncmsg"></span></h2>
+    <div class="sub" style="margin-bottom:8px">Re-import a workflow's defaults from its latest ComfyUI render. Tune the workflow in the ComfyUI UI, generate one image/video, then <b>Sync</b> — chat then uses your UI values (steps, LoRA, size…) and can override any exposed knob. <b>Preview</b> shows what would change without writing.</div>
+    <div id="wfsync">…</div>
+  </section>
   <section id="quietsec" style="display:none"><h2>Quiet hours <span class="hsub" id="quietstate"></span></h2>
     <div id="quietctl">…</div>
     <div class="sub" id="quiethint" style="margin-top:8px"></div>
@@ -1833,6 +1931,7 @@ async function refresh(){  try{
     // Quiet-hours toggle: pause/resume the nightly deep-idle window at runtime so a
     // long ComfyUI/LLM job can run through it without editing the unit.
     renderQuiet(d);
+    renderWorkflows(d);
   }catch(e){ document.getElementById('sub').textContent = 'status service error: ' + e; }
 }
 function renderQuiet(d){
@@ -1904,6 +2003,63 @@ async function comfyFp16(unit, enabled){
       : ('failed: '+(d.detail||d.error||r.status));
   }catch(e){ if(msg) msg.textContent='error: '+e; }
   finally{ setTimeout(refresh, 900); }
+}
+function renderWorkflows(d){
+  const sec=document.getElementById('wfsyncsec');
+  const wfs=d.workflows||[];
+  const canAct=d.actions && d.actions.workflow_sync;
+  if(!canAct || !wfs.length){ sec.style.display='none'; return; }
+  sec.style.display='';
+  const rows=wfs.map(w=>{
+    const exposed=(w.exposed||[]).join(', ')||'<span class="sub">none — run Sync</span>';
+    const upd=w.updated_at?('<span class="hsub">'+esc(String(w.updated_at).slice(0,19).replace('T',' '))+'</span>'):'<span class="hsub">never</span>';
+    const src='wfsrc_'+esc(w.id).replace(/[^A-Za-z0-9_-]/g,'_');
+    const ctrl=`<input id="${src}" class="wfsrc" placeholder="${esc(w.source_prefix)} (latest render)" style="width:180px">`
+      +` <button class="act" onclick="syncWorkflow('${esc(w.id)}',true)">🔍 Preview</button>`
+      +` <button class="act" onclick="syncWorkflow('${esc(w.id)}',false)">⬇ Sync</button>`;
+    return `<tr><td><b>${esc(w.id)}</b><br>${upd}</td><td class="sub">${exposed}</td><td>${ctrl}</td></tr>`;
+  });
+  document.getElementById('wfsync').innerHTML =
+    '<table><tr><th>Workflow</th><th>Exposed knobs</th><th>Source / Action</th></tr>'+rows.join('')+'</table>'
+    +'<div id="wfsyncout" class="sub" style="margin-top:8px;white-space:pre-wrap;font-family:monospace"></div>';
+}
+async function syncWorkflow(name, dryRun){
+  const msg=document.getElementById('wfsyncmsg');
+  const out=document.getElementById('wfsyncout');
+  const srcEl=document.getElementById('wfsrc_'+name.replace(/[^A-Za-z0-9_-]/g,'_'));
+  const source=srcEl?srcEl.value.trim():'';
+  document.querySelectorAll('#wfsync button.act').forEach(b=>b.disabled=true);
+  if(msg) msg.textContent=(dryRun?'previewing ':'syncing ')+name+'…';
+  try{
+    let q='actions/sync-workflow?name='+encodeURIComponent(name)+'&dry_run='+(dryRun?'true':'false');
+    if(source) q+='&source='+encodeURIComponent(source);
+    const r=await fetch(q,{method:'POST'});
+    const d=await r.json();
+    if(!d.ok){
+      const why=esc((d.report&&d.report.error)||d.error||('HTTP '+r.status));
+      if(msg) msg.textContent='failed';
+      if(out) out.textContent='✗ '+name+': '+why;
+      toast('Workflow sync failed: '+why, true);
+    } else {
+      const rep=d.report||{};
+      const ex=Object.keys(rep.exposed||{});
+      const sk=Object.keys(rep.skipped||{});
+      let txt=(dryRun?'PREVIEW ':'SYNCED ')+name+'  (source: '+esc(rep.source||'?')+')\n';
+      txt+='  exposed: '+(ex.join(', ')||'(none)')+'\n';
+      if(sk.length) txt+='  skipped: '+sk.map(k=>esc(k)+' ['+esc(rep.skipped[k])+']').join('; ')+'\n';
+      txt+='  defaults: '+esc(JSON.stringify(rep.defaults||{}))+'\n';
+      if(rep.restart_needed) txt+='  ⚠ exposed set changed — restart bridges to update the tool schema:\n    sudo systemctl restart comfyui-mcp comfyui-mcp-secure\n';
+      else txt+='  ✓ content hot-reloads (no restart needed)\n';
+      if(dryRun) txt+='  (preview only — nothing written)';
+      if(out) out.textContent=txt;
+      if(msg) msg.textContent=dryRun?'preview ready':'synced';
+      if(!dryRun) toast(name+' synced'+(rep.restart_needed?' — restart bridges to expose new knobs':''));
+    }
+  }catch(e){ if(msg) msg.textContent='error'; if(out) out.textContent='error: '+esc(String(e)); }
+  finally{
+    document.querySelectorAll('#wfsync button.act').forEach(b=>b.disabled=false);
+    if(!dryRun) setTimeout(refresh, 1200);
+  }
 }
 async function serviceAction(name, action){
   const msg=document.getElementById('svcmsg');
@@ -2089,6 +2245,33 @@ class Handler(BaseHTTPRequestHandler):
             _cache["at"] = 0.0  # force the next status poll to re-probe the limit
             body = json.dumps({
                 "ok": ok, "index": index, "watts": watts, "detail": detail[:500],
+            }).encode("utf-8")
+            self._send(200 if ok else 500, body, "application/json")
+        elif path == "/actions/sync-workflow":
+            # Re-import a ComfyUI workflow's defaults into the MCP bridge library
+            # from its latest render (see collect_workflows / _sync_workflow).
+            # Non-privileged (writes only COMFY_MCP_WORKFLOW_DIR as this user).
+            if not STATUS_ACTIONS_ENABLED or not WORKFLOW_SYNC_ENABLED:
+                self._send(403, json.dumps(
+                    {"ok": False, "error": "workflow sync disabled"}
+                ).encode("utf-8"), "application/json")
+                return
+            qs = urllib.parse.parse_qs(
+                self.path.split("?", 1)[1] if "?" in self.path else "")
+            name = (qs.get("name", [""])[0]).strip()
+            source = (qs.get("source", [""])[0]).strip()
+            dry_run = (qs.get("dry_run", ["false"])[0]).lower() in (
+                "1", "true", "yes", "on")
+            if not name:
+                self._send(400, json.dumps(
+                    {"ok": False, "error": "missing workflow name"}
+                ).encode("utf-8"), "application/json")
+                return
+            ok, report = _sync_workflow(name, source=source, dry_run=dry_run)
+            if ok and not dry_run:
+                _cache["at"] = 0.0  # force re-probe so the panel reflects new meta
+            body = json.dumps({
+                "ok": ok, "name": name, "dry_run": dry_run, "report": report,
             }).encode("utf-8")
             self._send(200 if ok else 500, body, "application/json")
         else:

--- a/scripts/server-status-service.py
+++ b/scripts/server-status-service.py
@@ -2044,12 +2044,12 @@ async function syncWorkflow(name, dryRun){
       const rep=d.report||{};
       const ex=Object.keys(rep.exposed||{});
       const sk=Object.keys(rep.skipped||{});
-      let txt=(dryRun?'PREVIEW ':'SYNCED ')+name+'  (source: '+esc(rep.source||'?')+')\n';
-      txt+='  exposed: '+(ex.join(', ')||'(none)')+'\n';
-      if(sk.length) txt+='  skipped: '+sk.map(k=>esc(k)+' ['+esc(rep.skipped[k])+']').join('; ')+'\n';
-      txt+='  defaults: '+esc(JSON.stringify(rep.defaults||{}))+'\n';
-      if(rep.restart_needed) txt+='  ⚠ exposed set changed — restart bridges to update the tool schema:\n    sudo systemctl restart comfyui-mcp comfyui-mcp-secure\n';
-      else txt+='  ✓ content hot-reloads (no restart needed)\n';
+      let txt=(dryRun?'PREVIEW ':'SYNCED ')+name+'  (source: '+esc(rep.source||'?')+')\\n';
+      txt+='  exposed: '+(ex.join(', ')||'(none)')+'\\n';
+      if(sk.length) txt+='  skipped: '+sk.map(k=>esc(k)+' ['+esc(rep.skipped[k])+']').join('; ')+'\\n';
+      txt+='  defaults: '+esc(JSON.stringify(rep.defaults||{}))+'\\n';
+      if(rep.restart_needed) txt+='  ⚠ exposed set changed — restart bridges to update the tool schema:\\n    sudo systemctl restart comfyui-mcp comfyui-mcp-secure\\n';
+      else txt+='  ✓ content hot-reloads (no restart needed)\\n';
       if(dryRun) txt+='  (preview only — nothing written)';
       if(out) out.textContent=txt;
       if(msg) msg.textContent=dryRun?'preview ready':'synced';
@@ -2180,6 +2180,7 @@ class Handler(BaseHTTPRequestHandler):
                 "ok": ok, "unit": unit, "enabled": enabled, "detail": detail[:500],
             }).encode("utf-8")
             self._send(200 if ok else 400, body, "application/json")
+        elif path == "/actions/service":
             # Start/stop a managed creative-tool service (Fooocus/SwarmUI/InvokeAI).
             # Each unit has its own line in the server-status sudoers file.
             if not STATUS_ACTIONS_ENABLED or not MANAGED_SERVICES:


### PR DESCRIPTION
Bundles the ComfyUI secure-bridge work plus follow-on fixes.

## Bridges
- Add a second ComfyUI MCP bridge for the secure (login-gated) instance; auth asset fetches + longer inline wait; suppress inline base64 preview when markdown mode is on.

## Workflow sync (a8421f4)
- Generic UI-defaults workflow sync: import a render's flattened API graph and honor the ComfyUI-UI defaults (steps/LoRA/size/sampler/length/fps/input_image) for ANY workflow (t2i, img2img, upscale, edit, video). Root cause of the steps=20 drift was hardcoded DefaultsManager fallbacks, not the model. Status-page panel + POST /actions/sync-workflow.

## LiteLLM (560eb79)
- Disable the Qwen3 thinking phase for Open WebUI background tasks (title/tags/follow-up/query) to kill post-generation churn.

## Status-page fixes (d85e631)
- Give the orphaned /actions/service handler its own `elif` so the managed-service (Fooocus/SwarmUI/InvokeAI) Start/Stop buttons route instead of 404; stops a stray second _send after the fp16 toggle reply.
- Escape six `\n` -> `\\n` in the syncWorkflow() JS (the page is a non-raw Python triple-quoted string, so literal newlines broke every JS string and took the page down).

## Docs (d85e631)
- AGENTS.md: reflect current GPUs — idx0 is a 12GB GTX Titan X (Maxwell sm_52) stopgap after the P100 HBM/ECC death (ADR-0017), with corrected GPU-order gotcha, hardware line, CUDA/thermal caps, and small/fast roster.

Tested: status page loads (JS syntax-checked with node), ComfyUI + secure bridges restarted, workflow-sync path integration-tested.